### PR TITLE
Support for Arquillian

### DIFF
--- a/com.ibm.jbatch.tck.exec/pom.xml
+++ b/com.ibm.jbatch.tck.exec/pom.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2012 International Business Machines Corp.
+   Copyright 2012 International Business Machines Corp.
 
-  See the NOTICE file distributed with this work for additional information
-  regarding copyright ownership. Licensed under the Apache License,
-  Version 2.0 (the "License"); you may not use this file except in compliance
-  with the License. You may obtain a copy of the License at
+   See the NOTICE file distributed with this work for additional information
+   regarding copyright ownership. Licensed under the Apache License,
+   Version 2.0 (the "License"); you may not use this file except in compliance
+   with the License. You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 
-  SPDX-License-Identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/com.ibm.jbatch.tck.exec/pom.xml
+++ b/com.ibm.jbatch.tck.exec/pom.xml
@@ -16,7 +16,7 @@
    limitations under the License.
 
    SPDX-License-Identifier: Apache-2.0
--->
+ -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -161,10 +161,11 @@
                         <configuration>
                             <suiteXmlFiles>
                                 <!-- Not sure how to reference the suite XML file within the dependency artifact, so rely on an unpacking first.-->
-                                <!--<suiteXmlFile>${project.build.directory}/test-classes/testng/batch-tck-impl-SE-suite.xml</suiteXmlFile>-->
+                                <suiteXmlFile>${project.build.directory}/test-classes/testng/batch-tck-impl-SE-suite.xml</suiteXmlFile>
                                 <!-- For debugging -->
-                                
+                                <!--
                                 <suiteXmlFile>${project.basedir}/testng.suite.xml</suiteXmlFile>
+-->
 
                             </suiteXmlFiles>
                             <systemPropertiesFile>${project.basedir}/test.properties</systemPropertiesFile>

--- a/com.ibm.jbatch.tck.exec/pom.xml
+++ b/com.ibm.jbatch.tck.exec/pom.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright 2012 International Business Machines Corp.
+  Copyright 2012 International Business Machines Corp.
 
-   See the NOTICE file distributed with this work for additional information
-   regarding copyright ownership. Licensed under the Apache License,
-   Version 2.0 (the "License"); you may not use this file except in compliance
-   with the License. You may obtain a copy of the License at
+  See the NOTICE file distributed with this work for additional information
+  regarding copyright ownership. Licensed under the Apache License,
+  Version 2.0 (the "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 
-   SPDX-License-Identifier: Apache-2.0
- -->
+  SPDX-License-Identifier: Apache-2.0
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -32,6 +32,10 @@
     <packaging>pom</packaging>
     <version>1.0.2</version>
     <name>Jakarta Batch TCK Execution (using JBatch, the former RI, against TCK Maven module)</name>
+
+    <properties>
+        <weld.core.version>3.1.3.Final</weld.core.version>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -85,9 +89,14 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-weld-embedded</artifactId>
+            <version>2.0.1.Final</version>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.weld.se</groupId>
-            <artifactId>weld-se</artifactId>
-            <scope>test</scope>
+            <artifactId>weld-se-shaded</artifactId>
+            <version>${weld.core.version}</version>
         </dependency>
     </dependencies>
 
@@ -152,11 +161,11 @@
                         <configuration>
                             <suiteXmlFiles>
                                 <!-- Not sure how to reference the suite XML file within the dependency artifact, so rely on an unpacking first.-->
-                                <suiteXmlFile>${project.build.directory}/test-classes/testng/batch-tck-impl-SE-suite.xml</suiteXmlFile>
+                                <!--<suiteXmlFile>${project.build.directory}/test-classes/testng/batch-tck-impl-SE-suite.xml</suiteXmlFile>-->
                                 <!-- For debugging -->
-                                <!--
+                                
                                 <suiteXmlFile>${project.basedir}/testng.suite.xml</suiteXmlFile>
--->
+
                             </suiteXmlFiles>
                             <systemPropertiesFile>${project.basedir}/test.properties</systemPropertiesFile>
                         </configuration>

--- a/com.ibm.jbatch.tck/pom.xml
+++ b/com.ibm.jbatch.tck/pom.xml
@@ -32,11 +32,6 @@
     <version>1.0.2</version>
     <name>Jakarta Batch TCK Core Test Artifacts</name>
 
-    <properties>
-        <weld.api.version>3.1.SP2</weld.api.version>
-        <weld.core.version>3.1.3.Final</weld.core.version>
-    </properties>
-
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -93,34 +88,14 @@
             <artifactId>xmlunit</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.arquillian.container</groupId>
-            <artifactId>arquillian-weld-embedded</artifactId>
-            <version>2.0.1.Final</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>            
-            <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.weld</groupId>
-            <artifactId>weld-api</artifactId>
-            <version>${weld.api.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.weld</groupId>
-            <artifactId>weld-spi</artifactId>
-            <version>${weld.api.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.weld</groupId>
-            <artifactId>weld-core-impl</artifactId>
-            <version>${weld.core.version}</version>
-            <scope>test</scope>
-        </dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-depchain</artifactId>
+            <type>pom</type>
+        </dependency>    
     </dependencies>
 
     <pluginRepositories>

--- a/com.ibm.jbatch.tck/pom.xml
+++ b/com.ibm.jbatch.tck/pom.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2012 International Business Machines Corp.
+   Copyright 2012 International Business Machines Corp.
 
-  See the NOTICE file distributed with this work for additional information
-  regarding copyright ownership. Licensed under the Apache License,
-  Version 2.0 (the "License"); you may not use this file except in compliance
-  with the License. You may obtain a copy of the License at
+   See the NOTICE file distributed with this work for additional information
+   regarding copyright ownership. Licensed under the Apache License,
+   Version 2.0 (the "License"); you may not use this file except in compliance
+   with the License. You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 
-  SPDX-License-Identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>jakarta.batch</groupId>
@@ -135,9 +135,9 @@
                             </configuration>
                         </execution>
                         <!-- By failing when the newly-generated batch.xml changes, we force someone to review
-                        the changes.   We purposely don't want to make it too easy to introduce a change here, 
-                        since this will ultimately affect the pass/failing of implementations' runs against the TCK.
-                        This will add as a guard that the person who would make the update knows what they're doing. -->
+                             the changes.   We purposely don't want to make it too easy to introduce a change here, 
+                             since this will ultimately affect the pass/failing of implementations' runs against the TCK.
+                             This will add as a guard that the person who would make the update knows what they're doing. -->
                         <execution>
                             <id>generate-batch.xml</id>
                             <goals>
@@ -173,8 +173,8 @@
                             </configuration>
                         </execution>
                         <!-- Updating the signature files should not be done lightly.  This changes the specified, public API. 
-                        We purposely make this fail by default when a signature is changed, to ensure
-                        that the person who would make the update knows what they're doing. -->
+                             We purposely make this fail by default when a signature is changed, to ensure
+                             that the person who would make the update knows what they're doing. -->
                         <execution>
                             <id>generate-sigtest</id>
                             <goals>
@@ -184,8 +184,8 @@
                             <configuration>
                                 <target>
                                     <!-- Note this simply uses the JRE level of the JRE executing Maven and generates the correspondng .sig file.
-                                    So to generate the Java 6, 7, 8 .sig files you have to actually run Maven using Java 6, 7, 8, respectively, 
-                                    once for each.  You can't just generate them all at once. -->
+                                         So to generate the Java 6, 7, 8 .sig files you have to actually run Maven using Java 6, 7, 8, respectively, 
+                                         once for each.  You can't just generate them all at once. -->
                                     <condition property="jdk" value="6">
                                         <contains string="${ant.java.version}" substring="1.6"/>
                                     </condition>
@@ -258,13 +258,13 @@
                     </archive>
                 </configuration>
             </plugin>
-            <plugin>
+              <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <skipTests>true</skipTests>
+                      <skipTests>true</skipTests>
                 </configuration>
-            </plugin>
+              </plugin>
         </plugins>
     </build>
     <profiles>
@@ -291,9 +291,7 @@
             <id>batchXML</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
-                <property>
-                    <name>batchXML</name>
-                </property>
+                <property><name>batchXML</name></property>
             </activation>
             <build>
                 <plugins>
@@ -314,9 +312,7 @@
             <id>sigtest</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
-                <property>
-                    <name>sigtest</name>
-                </property>
+                <property><name>sigtest</name></property>
             </activation>
             <build>
                 <plugins>

--- a/com.ibm.jbatch.tck/pom.xml
+++ b/com.ibm.jbatch.tck/pom.xml
@@ -16,7 +16,7 @@
    limitations under the License.
 
    SPDX-License-Identifier: Apache-2.0
--->
+ -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/com.ibm.jbatch.tck/pom.xml
+++ b/com.ibm.jbatch.tck/pom.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright 2012 International Business Machines Corp.
+  Copyright 2012 International Business Machines Corp.
 
-   See the NOTICE file distributed with this work for additional information
-   regarding copyright ownership. Licensed under the Apache License,
-   Version 2.0 (the "License"); you may not use this file except in compliance
-   with the License. You may obtain a copy of the License at
+  See the NOTICE file distributed with this work for additional information
+  regarding copyright ownership. Licensed under the Apache License,
+  Version 2.0 (the "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 
-   SPDX-License-Identifier: Apache-2.0
- -->
+  SPDX-License-Identifier: Apache-2.0
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>jakarta.batch</groupId>
@@ -31,6 +31,23 @@
     <packaging>jar</packaging>
     <version>1.0.2</version>
     <name>Jakarta Batch TCK Core Test Artifacts</name>
+
+    <properties>
+        <weld.api.version>3.1.SP2</weld.api.version>
+        <weld.core.version>3.1.3.Final</weld.core.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>1.6.0.Final</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -75,6 +92,35 @@
             <groupId>xmlunit</groupId>
             <artifactId>xmlunit</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-weld-embedded</artifactId>
+            <version>2.0.1.Final</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.testng</groupId>
+            <artifactId>arquillian-testng-container</artifactId>            
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-api</artifactId>
+            <version>${weld.api.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-spi</artifactId>
+            <version>${weld.api.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-core-impl</artifactId>
+            <version>${weld.core.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <pluginRepositories>
@@ -114,9 +160,9 @@
                             </configuration>
                         </execution>
                         <!-- By failing when the newly-generated batch.xml changes, we force someone to review
-                             the changes.   We purposely don't want to make it too easy to introduce a change here, 
-                             since this will ultimately affect the pass/failing of implementations' runs against the TCK.
-                             This will add as a guard that the person who would make the update knows what they're doing. -->
+                        the changes.   We purposely don't want to make it too easy to introduce a change here, 
+                        since this will ultimately affect the pass/failing of implementations' runs against the TCK.
+                        This will add as a guard that the person who would make the update knows what they're doing. -->
                         <execution>
                             <id>generate-batch.xml</id>
                             <goals>
@@ -152,8 +198,8 @@
                             </configuration>
                         </execution>
                         <!-- Updating the signature files should not be done lightly.  This changes the specified, public API. 
-                             We purposely make this fail by default when a signature is changed, to ensure
-                             that the person who would make the update knows what they're doing. -->
+                        We purposely make this fail by default when a signature is changed, to ensure
+                        that the person who would make the update knows what they're doing. -->
                         <execution>
                             <id>generate-sigtest</id>
                             <goals>
@@ -163,8 +209,8 @@
                             <configuration>
                                 <target>
                                     <!-- Note this simply uses the JRE level of the JRE executing Maven and generates the correspondng .sig file.
-                                         So to generate the Java 6, 7, 8 .sig files you have to actually run Maven using Java 6, 7, 8, respectively, 
-                                         once for each.  You can't just generate them all at once. -->
+                                    So to generate the Java 6, 7, 8 .sig files you have to actually run Maven using Java 6, 7, 8, respectively, 
+                                    once for each.  You can't just generate them all at once. -->
                                     <condition property="jdk" value="6">
                                         <contains string="${ant.java.version}" substring="1.6"/>
                                     </condition>
@@ -237,13 +283,13 @@
                     </archive>
                 </configuration>
             </plugin>
-              <plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                      <skipTests>true</skipTests>
+                    <skipTests>true</skipTests>
                 </configuration>
-              </plugin>
+            </plugin>
         </plugins>
     </build>
     <profiles>
@@ -270,7 +316,9 @@
             <id>batchXML</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
-                <property><name>batchXML</name></property>
+                <property>
+                    <name>batchXML</name>
+                </property>
             </activation>
             <build>
                 <plugins>
@@ -291,7 +339,9 @@
             <id>sigtest</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
-                <property><name>sigtest</name></property>
+                <property>
+                    <name>sigtest</name>
+                </property>
             </activation>
             <build>
                 <plugins>

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/AbstractTest.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/AbstractTest.java
@@ -1,10 +1,8 @@
 package com.ibm.jbatch.tck.tests;
 
-import java.io.File;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.*;
-import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.resolver.api.maven.*;
 
@@ -32,7 +30,6 @@ public class AbstractTest extends Arquillian {
                 archive = archive.addAsLibrary(artifact.asFile());
             }
         }
-        archive.as(ZipExporter.class).exportTo(new File("/tmp/arquillian.war"), true);
         return archive;
     }
 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/AbstractTest.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/AbstractTest.java
@@ -1,36 +1,10 @@
 package com.ibm.jbatch.tck.tests;
 
-import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
-import org.jboss.shrinkwrap.api.*;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.resolver.api.maven.*;
 
+/**
+ * Enables Arquillian for tests that extend it. All required work like preparing a deployment is done using arquillian extensions
+ */
 public class AbstractTest extends Arquillian {
-
-//    @Deployment
-    public static WebArchive createTestArchive() {
-        MavenResolvedArtifact[] resolvedArtifacts = Maven.resolver().loadPomFromFile("pom.xml")
-                .importDependencies(ScopeType.COMPILE, ScopeType.TEST)
-                .resolve().withTransitivity().asResolvedArtifact();
-        
-        WebArchive archive = ShrinkWrap
-                .create(WebArchive.class, "jbatch-test-package-all.war")
-                .as(WebArchive.class);
-        
-        for (MavenResolvedArtifact artifact : resolvedArtifacts) {
-            String groupId = artifact.getCoordinate().getGroupId();
-            String artifactId = artifact.getCoordinate().getArtifactId();
-            if (groupId.startsWith("org.jboss.shrinkwrap")
-                    || groupId.startsWith("org.codehaus.plexus")
-                    || groupId.startsWith("org.apache.maven")) {
-                continue;
-            }
-            if ("jar".equals(artifact.getExtension())) {
-                archive = archive.addAsLibrary(artifact.asFile());
-            }
-        }
-        return archive;
-    }
 
 }

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/AbstractTest.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/AbstractTest.java
@@ -3,7 +3,7 @@ package com.ibm.jbatch.tck.tests;
 import java.io.File;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.*;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.resolver.api.maven.*;
@@ -15,19 +15,21 @@ public class AbstractTest extends Arquillian {
         MavenResolvedArtifact[] resolvedArtifacts = Maven.resolver().loadPomFromFile("pom.xml")
                 .importDependencies(ScopeType.COMPILE, ScopeType.TEST)
                 .resolve().withTransitivity().asResolvedArtifact();
+        
         WebArchive archive = ShrinkWrap
                 .create(WebArchive.class, "jbatch-test-package-all.war")
-                .addPackages(true, "com.ibm.jbatch.tck")
                 .as(WebArchive.class);
+        
         for (MavenResolvedArtifact artifact : resolvedArtifacts) {
             String groupId = artifact.getCoordinate().getGroupId();
+            String artifactId = artifact.getCoordinate().getArtifactId();
             if (groupId.startsWith("org.jboss.shrinkwrap")
                     || groupId.startsWith("org.codehaus.plexus")
                     || groupId.startsWith("org.apache.maven")) {
                 continue;
             }
             if ("jar".equals(artifact.getExtension())) {
-                archive.addAsLibrary(artifact.asFile());
+                archive = archive.addAsLibrary(artifact.asFile());
             }
         }
         archive.as(ZipExporter.class).exportTo(new File("/tmp/arquillian.war"), true);

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/AbstractTest.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/AbstractTest.java
@@ -1,0 +1,37 @@
+package com.ibm.jbatch.tck.tests;
+
+import java.io.File;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.*;
+
+public class AbstractTest extends Arquillian {
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        MavenResolvedArtifact[] resolvedArtifacts = Maven.resolver().loadPomFromFile("pom.xml")
+                .importDependencies(ScopeType.COMPILE, ScopeType.TEST)
+                .resolve().withTransitivity().asResolvedArtifact();
+        WebArchive archive = ShrinkWrap
+                .create(WebArchive.class, "jbatch-test-package-all.war")
+                .addPackages(true, "com.ibm.jbatch.tck")
+                .as(WebArchive.class);
+        for (MavenResolvedArtifact artifact : resolvedArtifacts) {
+            String groupId = artifact.getCoordinate().getGroupId();
+            if (groupId.startsWith("org.jboss.shrinkwrap")
+                    || groupId.startsWith("org.codehaus.plexus")
+                    || groupId.startsWith("org.apache.maven")) {
+                continue;
+            }
+            if ("jar".equals(artifact.getExtension())) {
+                archive.addAsLibrary(artifact.asFile());
+            }
+        }
+        archive.as(ZipExporter.class).exportTo(new File("/tmp/arquillian.war"), true);
+        return archive;
+    }
+
+}

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/AbstractTest.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/AbstractTest.java
@@ -8,7 +8,7 @@ import org.jboss.shrinkwrap.resolver.api.maven.*;
 
 public class AbstractTest extends Arquillian {
 
-    @Deployment
+//    @Deployment
     public static WebArchive createTestArchive() {
         MavenResolvedArtifact[] resolvedArtifacts = Maven.resolver().loadPomFromFile("pom.xml")
                 .importDependencies(ScopeType.COMPILE, ScopeType.TEST)

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/ee/TransactionTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/ee/TransactionTests.java
@@ -39,8 +39,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-// Since we don't want to run these in SE, and are only really running TestNG in EE, we
-// can safely do a JUnit @Ignore without missing anything.
 public class TransactionTests extends AbstractTest {
 
 	private final static Logger logger = Logger.getLogger(TransactionTests.class.getName());

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/ee/TransactionTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/ee/TransactionTests.java
@@ -18,6 +18,7 @@
  */
 package com.ibm.jbatch.tck.tests.ee;
 
+import com.ibm.jbatch.tck.tests.AbstractTest;
 import static com.ibm.jbatch.tck.utils.AssertionUtils.assertObjEquals;
 import static com.ibm.jbatch.tck.utils.AssertionUtils.assertWithMessage;
 
@@ -33,7 +34,6 @@ import com.ibm.jbatch.tck.utils.JobOperatorBridge;
 import com.ibm.jbatch.tck.utils.TCKJobExecutionWrapper;
 
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.testng.Reporter;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeMethod;
@@ -41,8 +41,7 @@ import org.testng.annotations.Test;
 
 // Since we don't want to run these in SE, and are only really running TestNG in EE, we
 // can safely do a JUnit @Ignore without missing anything.
-@Ignore
-public class TransactionTests {
+public class TransactionTests extends AbstractTest {
 
 	private final static Logger logger = Logger.getLogger(TransactionTests.class.getName());
 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/BatchletRestartStateMachineTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/BatchletRestartStateMachineTests.java
@@ -18,6 +18,7 @@
  */
 package com.ibm.jbatch.tck.tests.jslxml;
 
+import com.ibm.jbatch.tck.tests.AbstractTest;
 import static com.ibm.jbatch.tck.utils.AssertionUtils.assertWithMessage;
 
 import java.util.Properties;
@@ -32,34 +33,33 @@ import org.testng.annotations.Test;
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
 import com.ibm.jbatch.tck.utils.TCKJobExecutionWrapper;
 
-public class BatchletRestartStateMachineTests {
+public class BatchletRestartStateMachineTests extends AbstractTest {
 
-	private static JobOperatorBridge jobOp = null;
+    private static JobOperatorBridge jobOp = null;
 
-	public static void setup(String[] args, Properties props) throws Exception {
+    public static void setup(String[] args, Properties props) throws Exception {
 
-		String METHOD = "setup";
+        String METHOD = "setup";
 
-		try {
-			jobOp = new JobOperatorBridge();
-		} catch (Exception e) {
-			handleException(METHOD, e);
-		}
-	}
+        try {
+            jobOp = new JobOperatorBridge();
+        } catch (Exception e) {
+            handleException(METHOD, e);
+        }
+    }
 
-	@BeforeMethod
-	@BeforeClass
-	public static void setUp() throws Exception {
-		jobOp = new JobOperatorBridge();
-	}
+    @BeforeMethod
+    @BeforeClass
+    public static void setUp() throws Exception {
+        jobOp = new JobOperatorBridge();
+    }
 
-	/* cleanup */
-	public void  cleanup()
-	{		
+    /* cleanup */
+    public void cleanup() {
 
-	}
+    }
 
-	/*
+    /*
 	 * @testName: testTransitionElementOnAttrValuesWithRestartJobParamOverrides
 	 * @assertion: 1) Tests Exit Status globbing against transition elements @on value 
 	 *             2) Shows that the @on values are overrideable on restart, and the persisted exit status in matched against the @on values coming
@@ -107,93 +107,93 @@ public class BatchletRestartStateMachineTests {
 	 * Note that because we reuse the same batchlet across the three steps we perform some validation in 
 	 * the batchlet, using the stepName and the execution number (as restart parameter), so that we validate we're never called
 	 * in the wrong step in the wrong execution (e.g. in execution.number N we shouldn't be in step S).
-	 */
-	@Test
-	@org.junit.Test
-	public void testTransitionElementOnAttrValuesWithRestartJobParamOverrides() throws Exception {
+     */
+    @Test
+    @org.junit.Test
+    public void testTransitionElementOnAttrValuesWithRestartJobParamOverrides() throws Exception {
 
-		String METHOD = "testTransitionElementOnAttrValuesWithRestartJobParamOverrides";
+        String METHOD = "testTransitionElementOnAttrValuesWithRestartJobParamOverrides";
 
-		String EXECUTION2_EXPECTED_EXIT_STATUS_FROM_JSL_ATTRIBUTE = "EXPECTED_FAILURE";
-		try {
+        String EXECUTION2_EXPECTED_EXIT_STATUS_FROM_JSL_ATTRIBUTE = "EXPECTED_FAILURE";
+        try {
 
-			TCKJobExecutionWrapper execution1 = null;
-			TCKJobExecutionWrapper execution2 = null;
-			TCKJobExecutionWrapper execution3 = null;
+            TCKJobExecutionWrapper execution1 = null;
+            TCKJobExecutionWrapper execution2 = null;
+            TCKJobExecutionWrapper execution3 = null;
 
-			// Create new block to facilitate copy-pasting without inadvertent errors
-			{
-				Reporter.log("Create job parameters for execution #1:<p>");
-				Properties jobParams = new Properties();
-				Reporter.log("execution.number=1<p>");
-				jobParams.setProperty("execution.number", "1");
-				jobParams.setProperty("step1.stop", "ES.STEP1");
-				jobParams.setProperty("step1.next", "ES.XXX");
-				jobParams.setProperty("step2.fail", "ES.STEP2");
-				jobParams.setProperty("step2.next", "ES.XXX");
+            // Create new block to facilitate copy-pasting without inadvertent errors
+            {
+                Reporter.log("Create job parameters for execution #1:<p>");
+                Properties jobParams = new Properties();
+                Reporter.log("execution.number=1<p>");
+                jobParams.setProperty("execution.number", "1");
+                jobParams.setProperty("step1.stop", "ES.STEP1");
+                jobParams.setProperty("step1.next", "ES.XXX");
+                jobParams.setProperty("step2.fail", "ES.STEP2");
+                jobParams.setProperty("step2.next", "ES.XXX");
 
-				Reporter.log("Invoke startJobAndWaitForResult");
-				execution1 = jobOp.startJobAndWaitForResult("overrideOnAttributeValuesUponRestartBatchlet", jobParams);
+                Reporter.log("Invoke startJobAndWaitForResult");
+                execution1 = jobOp.startJobAndWaitForResult("overrideOnAttributeValuesUponRestartBatchlet", jobParams);
 
-				Reporter.log("execution #1 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
-				Reporter.log("execution #1 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
-				assertWithMessage("Testing execution #1", BatchStatus.STOPPED, execution1.getBatchStatus());
-				assertWithMessage("Testing execution #1", "STOPPED", execution1.getExitStatus());
-			}
+                Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+                Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+                assertWithMessage("Testing execution #1", BatchStatus.STOPPED, execution1.getBatchStatus());
+                assertWithMessage("Testing execution #1", "STOPPED", execution1.getExitStatus());
+            }
 
-			{
-				Reporter.log("Create job parameters for execution #2:<p>");
-				Properties restartJobParameters = new Properties();
-				Reporter.log("execution.number=2<p>");
-				Reporter.log("step1.stop=ES.STOP<p>");
-				Reporter.log("step1.next=ES.STEP1<p>");
-				restartJobParameters.setProperty("execution.number", "2");
-				restartJobParameters.setProperty("step1.stop", "ES.STOP");
-				restartJobParameters.setProperty("step1.next", "ES.STEP1");
-				restartJobParameters.setProperty("step2.fail", "ES.STEP2");
-				restartJobParameters.setProperty("step2.next", "ES.STEP2");
-				Reporter.log("Invoke restartJobAndWaitForResult with executionId: " + execution1.getExecutionId() + "<p>");
-				execution2 = jobOp.restartJobAndWaitForResult(execution1.getExecutionId(),restartJobParameters);				
-				Reporter.log("execution #2 JobExecution getBatchStatus()="+execution2.getBatchStatus()+"<p>");
-				Reporter.log("execution #2 JobExecution getExitStatus()="+execution2.getExitStatus()+"<p>");
-				assertWithMessage("Testing execution #2", BatchStatus.FAILED, execution2.getBatchStatus());
-				// See JSL snippet above for where "SUCCESS" comes from
-				assertWithMessage("Testing execution #2", EXECUTION2_EXPECTED_EXIT_STATUS_FROM_JSL_ATTRIBUTE, execution2.getExitStatus());				
-			}
+            {
+                Reporter.log("Create job parameters for execution #2:<p>");
+                Properties restartJobParameters = new Properties();
+                Reporter.log("execution.number=2<p>");
+                Reporter.log("step1.stop=ES.STOP<p>");
+                Reporter.log("step1.next=ES.STEP1<p>");
+                restartJobParameters.setProperty("execution.number", "2");
+                restartJobParameters.setProperty("step1.stop", "ES.STOP");
+                restartJobParameters.setProperty("step1.next", "ES.STEP1");
+                restartJobParameters.setProperty("step2.fail", "ES.STEP2");
+                restartJobParameters.setProperty("step2.next", "ES.STEP2");
+                Reporter.log("Invoke restartJobAndWaitForResult with executionId: " + execution1.getExecutionId() + "<p>");
+                execution2 = jobOp.restartJobAndWaitForResult(execution1.getExecutionId(), restartJobParameters);
+                Reporter.log("execution #2 JobExecution getBatchStatus()=" + execution2.getBatchStatus() + "<p>");
+                Reporter.log("execution #2 JobExecution getExitStatus()=" + execution2.getExitStatus() + "<p>");
+                assertWithMessage("Testing execution #2", BatchStatus.FAILED, execution2.getBatchStatus());
+                // See JSL snippet above for where "SUCCESS" comes from
+                assertWithMessage("Testing execution #2", EXECUTION2_EXPECTED_EXIT_STATUS_FROM_JSL_ATTRIBUTE, execution2.getExitStatus());
+            }
 
-			{
-				Reporter.log("Create job parameters for execution #3:<p>");
-				Properties restartJobParameters = new Properties();
-				Reporter.log("execution.number=3<p>");
-				Reporter.log("step1.stop=ES.STOP<p>");
-				Reporter.log("step1.next=ES.STEP1<p>");
-				Reporter.log("step2.fail=ES.FAIL<p>");
-				Reporter.log("step2.next=ES.STEP2<p>");
-				restartJobParameters.setProperty("execution.number", "3");
-				restartJobParameters.setProperty("step1.stop", "ES.STOP");
-				restartJobParameters.setProperty("step1.next", "ES.STEP1");
-				restartJobParameters.setProperty("step2.fail", "ES.FAIL");
-				restartJobParameters.setProperty("step2.next", "ES.STEP2");
-				Reporter.log("Invoke restartJobAndWaitForResult with executionId: " + execution2.getExecutionId() + "<p>");
-				execution3 = jobOp.restartJobAndWaitForResult(execution2.getExecutionId(),restartJobParameters);
-				Reporter.log("execution #3 JobExecution getBatchStatus()="+execution3.getBatchStatus()+"<p>");
-				Reporter.log("execution #3 JobExecution getExitStatus()="+execution3.getExitStatus()+"<p>");				
-				assertWithMessage("Testing execution #3", BatchStatus.COMPLETED, execution3.getBatchStatus());
-				assertWithMessage("Testing execution #3", "COMPLETED", execution3.getExitStatus());  
-			}
-		} catch (Exception e) {
-			handleException(METHOD, e);
-		}
+            {
+                Reporter.log("Create job parameters for execution #3:<p>");
+                Properties restartJobParameters = new Properties();
+                Reporter.log("execution.number=3<p>");
+                Reporter.log("step1.stop=ES.STOP<p>");
+                Reporter.log("step1.next=ES.STEP1<p>");
+                Reporter.log("step2.fail=ES.FAIL<p>");
+                Reporter.log("step2.next=ES.STEP2<p>");
+                restartJobParameters.setProperty("execution.number", "3");
+                restartJobParameters.setProperty("step1.stop", "ES.STOP");
+                restartJobParameters.setProperty("step1.next", "ES.STEP1");
+                restartJobParameters.setProperty("step2.fail", "ES.FAIL");
+                restartJobParameters.setProperty("step2.next", "ES.STEP2");
+                Reporter.log("Invoke restartJobAndWaitForResult with executionId: " + execution2.getExecutionId() + "<p>");
+                execution3 = jobOp.restartJobAndWaitForResult(execution2.getExecutionId(), restartJobParameters);
+                Reporter.log("execution #3 JobExecution getBatchStatus()=" + execution3.getBatchStatus() + "<p>");
+                Reporter.log("execution #3 JobExecution getExitStatus()=" + execution3.getExitStatus() + "<p>");
+                assertWithMessage("Testing execution #3", BatchStatus.COMPLETED, execution3.getBatchStatus());
+                assertWithMessage("Testing execution #3", "COMPLETED", execution3.getExitStatus());
+            }
+        } catch (Exception e) {
+            handleException(METHOD, e);
+        }
 
-	}
+    }
 
-	/*
+    /*
 	 * Obviously would be nicer to have more granular tests for some of this function,
 	 * but here we're going a different route and saying, if it's going to require
 	 * restart it will have some complexity, so let's test a few different functions
 	 * in one longer restart scenario.
-	 */
-	/*
+     */
+ /*
 	 * @testName: testAllowStartIfCompleteRestartExecution
 	 * @assertion:    1. @restart attribute on <stop> transition element
 	 *           :    2. tests difference between allow-start-if-complete = true or false (default)
@@ -233,49 +233,49 @@ public class BatchletRestartStateMachineTests {
 	 * Note that because we reuse the same batchlet across the three steps we perform some validation in 
 	 * the batchlet, using the stepName and the execution number (as restart parameter), so that we validate we're never called
 	 * in the wrong step in the wrong execution (e.g. in execution.number N we shouldn't be in step S).
-	 */
-	@Test
-	@org.junit.Test
-	public void testAllowStartIfCompleteRestartExecution() throws Exception {
+     */
+    @Test
+    @org.junit.Test
+    public void testAllowStartIfCompleteRestartExecution() throws Exception {
 
-		String METHOD = "testAllowStartIfCompleteRestartExecution";
+        String METHOD = "testAllowStartIfCompleteRestartExecution";
 
-		try {
-			long lastExecutionId = 0L;
-			TCKJobExecutionWrapper exec = null;
+        try {
+            long lastExecutionId = 0L;
+            TCKJobExecutionWrapper exec = null;
 
-			for (int i = 1; i <= 6; i++) {
-				String execString = new Integer(i).toString();
-				Properties jobParameters = new Properties();
-				jobParameters.put("execution.number", execString);
-				if (i == 1) {
-					Reporter.log("Invoking startJobAndWaitForResult for Execution #1<p>");
-					exec = jobOp.startJobAndWaitForResult("batchletRestartStateMachine", jobParameters);
-				} else {
-					Reporter.log("Invoke restartJobAndWaitForResult<p>");
-					exec = jobOp.restartJobAndWaitForResult(lastExecutionId, jobParameters);
-				}
-				lastExecutionId = exec.getExecutionId();
+            for (int i = 1; i <= 6; i++) {
+                String execString = new Integer(i).toString();
+                Properties jobParameters = new Properties();
+                jobParameters.put("execution.number", execString);
+                if (i == 1) {
+                    Reporter.log("Invoking startJobAndWaitForResult for Execution #1<p>");
+                    exec = jobOp.startJobAndWaitForResult("batchletRestartStateMachine", jobParameters);
+                } else {
+                    Reporter.log("Invoke restartJobAndWaitForResult<p>");
+                    exec = jobOp.restartJobAndWaitForResult(lastExecutionId, jobParameters);
+                }
+                lastExecutionId = exec.getExecutionId();
 
-				Reporter.log("Execution #" + i + " JobExecution getBatchStatus()="+exec.getBatchStatus()+"<p>");
-				Reporter.log("Execution #" + i + " JobExecution getExitStatus()="+exec.getExitStatus()+"<p>");
-				if (i == 6) {
-					assertWithMessage("Testing execution #" + i, BatchStatus.COMPLETED, exec.getBatchStatus());
-				} else {
-					assertWithMessage("Testing execution #" + i, BatchStatus.STOPPED, exec.getBatchStatus());
-				}
-				assertWithMessage("Testing execution #" + i, "EXECUTION." + execString, exec.getExitStatus());
-			}
-		} catch (Exception e) {
-			handleException(METHOD, e);
-		}
+                Reporter.log("Execution #" + i + " JobExecution getBatchStatus()=" + exec.getBatchStatus() + "<p>");
+                Reporter.log("Execution #" + i + " JobExecution getExitStatus()=" + exec.getExitStatus() + "<p>");
+                if (i == 6) {
+                    assertWithMessage("Testing execution #" + i, BatchStatus.COMPLETED, exec.getBatchStatus());
+                } else {
+                    assertWithMessage("Testing execution #" + i, BatchStatus.STOPPED, exec.getBatchStatus());
+                }
+                assertWithMessage("Testing execution #" + i, "EXECUTION." + execString, exec.getExitStatus());
+            }
+        } catch (Exception e) {
+            handleException(METHOD, e);
+        }
 
-	}
-	
-	private static void handleException(String methodName, Exception e) throws Exception {
-		Reporter.log("Caught exception: " + e.getMessage()+"<p>");
-		Reporter.log(methodName + " failed<p>");
-		throw e;
-	}
+    }
+
+    private static void handleException(String methodName, Exception e) throws Exception {
+        Reporter.log("Caught exception: " + e.getMessage() + "<p>");
+        Reporter.log(methodName + " failed<p>");
+        throw e;
+    }
 
 }

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/BatchletRestartStateMachineTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/BatchletRestartStateMachineTests.java
@@ -22,7 +22,7 @@ import com.ibm.jbatch.tck.tests.AbstractTest;
 import static com.ibm.jbatch.tck.utils.AssertionUtils.assertWithMessage;
 
 import java.util.Properties;
- 
+
 import javax.batch.runtime.BatchStatus;
 
 import org.junit.BeforeClass;
@@ -35,32 +35,32 @@ import com.ibm.jbatch.tck.utils.TCKJobExecutionWrapper;
 
 public class BatchletRestartStateMachineTests extends AbstractTest {
 
-    private static JobOperatorBridge jobOp = null;
+	private static JobOperatorBridge jobOp = null;
 
-    public static void setup(String[] args, Properties props) throws Exception {
+	public static void setup(String[] args, Properties props) throws Exception {
 
-        String METHOD = "setup";
+		String METHOD = "setup";
 
-        try {
-            jobOp = new JobOperatorBridge();
-        } catch (Exception e) {
-            handleException(METHOD, e);
-        }
-    }
+		try {
+			jobOp = new JobOperatorBridge();
+		} catch (Exception e) {
+			handleException(METHOD, e);
+		}
+	}
 
-    @BeforeMethod
-    @BeforeClass
-    public static void setUp() throws Exception {
-        jobOp = new JobOperatorBridge();
-    }
+	@BeforeMethod
+	@BeforeClass
+	public static void setUp() throws Exception {
+		jobOp = new JobOperatorBridge();
+	}
 
-    /* cleanup */
+	/* cleanup */
 	public void  cleanup()
 	{		
 
-    }
+	}
 
-    /*
+	/*
 	 * @testName: testTransitionElementOnAttrValuesWithRestartJobParamOverrides
 	 * @assertion: 1) Tests Exit Status globbing against transition elements @on value 
 	 *             2) Shows that the @on values are overrideable on restart, and the persisted exit status in matched against the @on values coming
@@ -108,93 +108,93 @@ public class BatchletRestartStateMachineTests extends AbstractTest {
 	 * Note that because we reuse the same batchlet across the three steps we perform some validation in 
 	 * the batchlet, using the stepName and the execution number (as restart parameter), so that we validate we're never called
 	 * in the wrong step in the wrong execution (e.g. in execution.number N we shouldn't be in step S).
-     */
-    @Test
-    @org.junit.Test
-    public void testTransitionElementOnAttrValuesWithRestartJobParamOverrides() throws Exception {
+	 */
+	@Test
+	@org.junit.Test
+	public void testTransitionElementOnAttrValuesWithRestartJobParamOverrides() throws Exception {
 
-        String METHOD = "testTransitionElementOnAttrValuesWithRestartJobParamOverrides";
+		String METHOD = "testTransitionElementOnAttrValuesWithRestartJobParamOverrides";
 
-        String EXECUTION2_EXPECTED_EXIT_STATUS_FROM_JSL_ATTRIBUTE = "EXPECTED_FAILURE";
-        try {
+		String EXECUTION2_EXPECTED_EXIT_STATUS_FROM_JSL_ATTRIBUTE = "EXPECTED_FAILURE";
+		try {
 
-            TCKJobExecutionWrapper execution1 = null;
-            TCKJobExecutionWrapper execution2 = null;
-            TCKJobExecutionWrapper execution3 = null;
+			TCKJobExecutionWrapper execution1 = null;
+			TCKJobExecutionWrapper execution2 = null;
+			TCKJobExecutionWrapper execution3 = null;
 
-            // Create new block to facilitate copy-pasting without inadvertent errors
-            {
-                Reporter.log("Create job parameters for execution #1:<p>");
-                Properties jobParams = new Properties();
-                Reporter.log("execution.number=1<p>");
-                jobParams.setProperty("execution.number", "1");
-                jobParams.setProperty("step1.stop", "ES.STEP1");
-                jobParams.setProperty("step1.next", "ES.XXX");
-                jobParams.setProperty("step2.fail", "ES.STEP2");
-                jobParams.setProperty("step2.next", "ES.XXX");
+			// Create new block to facilitate copy-pasting without inadvertent errors
+			{
+				Reporter.log("Create job parameters for execution #1:<p>");
+				Properties jobParams = new Properties();
+				Reporter.log("execution.number=1<p>");
+				jobParams.setProperty("execution.number", "1");
+				jobParams.setProperty("step1.stop", "ES.STEP1");
+				jobParams.setProperty("step1.next", "ES.XXX");
+				jobParams.setProperty("step2.fail", "ES.STEP2");
+				jobParams.setProperty("step2.next", "ES.XXX");
 
-                Reporter.log("Invoke startJobAndWaitForResult");
-                execution1 = jobOp.startJobAndWaitForResult("overrideOnAttributeValuesUponRestartBatchlet", jobParams);
+				Reporter.log("Invoke startJobAndWaitForResult");
+				execution1 = jobOp.startJobAndWaitForResult("overrideOnAttributeValuesUponRestartBatchlet", jobParams);
 
 				Reporter.log("execution #1 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
 				Reporter.log("execution #1 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
-                assertWithMessage("Testing execution #1", BatchStatus.STOPPED, execution1.getBatchStatus());
-                assertWithMessage("Testing execution #1", "STOPPED", execution1.getExitStatus());
-            }
+				assertWithMessage("Testing execution #1", BatchStatus.STOPPED, execution1.getBatchStatus());
+				assertWithMessage("Testing execution #1", "STOPPED", execution1.getExitStatus());
+			}
 
-            {
-                Reporter.log("Create job parameters for execution #2:<p>");
-                Properties restartJobParameters = new Properties();
-                Reporter.log("execution.number=2<p>");
-                Reporter.log("step1.stop=ES.STOP<p>");
-                Reporter.log("step1.next=ES.STEP1<p>");
-                restartJobParameters.setProperty("execution.number", "2");
-                restartJobParameters.setProperty("step1.stop", "ES.STOP");
-                restartJobParameters.setProperty("step1.next", "ES.STEP1");
-                restartJobParameters.setProperty("step2.fail", "ES.STEP2");
-                restartJobParameters.setProperty("step2.next", "ES.STEP2");
-                Reporter.log("Invoke restartJobAndWaitForResult with executionId: " + execution1.getExecutionId() + "<p>");
+			{
+				Reporter.log("Create job parameters for execution #2:<p>");
+				Properties restartJobParameters = new Properties();
+				Reporter.log("execution.number=2<p>");
+				Reporter.log("step1.stop=ES.STOP<p>");
+				Reporter.log("step1.next=ES.STEP1<p>");
+				restartJobParameters.setProperty("execution.number", "2");
+				restartJobParameters.setProperty("step1.stop", "ES.STOP");
+				restartJobParameters.setProperty("step1.next", "ES.STEP1");
+				restartJobParameters.setProperty("step2.fail", "ES.STEP2");
+				restartJobParameters.setProperty("step2.next", "ES.STEP2");
+				Reporter.log("Invoke restartJobAndWaitForResult with executionId: " + execution1.getExecutionId() + "<p>");
 				execution2 = jobOp.restartJobAndWaitForResult(execution1.getExecutionId(),restartJobParameters);				
 				Reporter.log("execution #2 JobExecution getBatchStatus()="+execution2.getBatchStatus()+"<p>");
 				Reporter.log("execution #2 JobExecution getExitStatus()="+execution2.getExitStatus()+"<p>");
-                assertWithMessage("Testing execution #2", BatchStatus.FAILED, execution2.getBatchStatus());
-                // See JSL snippet above for where "SUCCESS" comes from
-                assertWithMessage("Testing execution #2", EXECUTION2_EXPECTED_EXIT_STATUS_FROM_JSL_ATTRIBUTE, execution2.getExitStatus());
-            }
+				assertWithMessage("Testing execution #2", BatchStatus.FAILED, execution2.getBatchStatus());
+				// See JSL snippet above for where "SUCCESS" comes from
+				assertWithMessage("Testing execution #2", EXECUTION2_EXPECTED_EXIT_STATUS_FROM_JSL_ATTRIBUTE, execution2.getExitStatus());				
+			}
 
-            {
-                Reporter.log("Create job parameters for execution #3:<p>");
-                Properties restartJobParameters = new Properties();
-                Reporter.log("execution.number=3<p>");
-                Reporter.log("step1.stop=ES.STOP<p>");
-                Reporter.log("step1.next=ES.STEP1<p>");
-                Reporter.log("step2.fail=ES.FAIL<p>");
-                Reporter.log("step2.next=ES.STEP2<p>");
-                restartJobParameters.setProperty("execution.number", "3");
-                restartJobParameters.setProperty("step1.stop", "ES.STOP");
-                restartJobParameters.setProperty("step1.next", "ES.STEP1");
-                restartJobParameters.setProperty("step2.fail", "ES.FAIL");
-                restartJobParameters.setProperty("step2.next", "ES.STEP2");
-                Reporter.log("Invoke restartJobAndWaitForResult with executionId: " + execution2.getExecutionId() + "<p>");
+			{
+				Reporter.log("Create job parameters for execution #3:<p>");
+				Properties restartJobParameters = new Properties();
+				Reporter.log("execution.number=3<p>");
+				Reporter.log("step1.stop=ES.STOP<p>");
+				Reporter.log("step1.next=ES.STEP1<p>");
+				Reporter.log("step2.fail=ES.FAIL<p>");
+				Reporter.log("step2.next=ES.STEP2<p>");
+				restartJobParameters.setProperty("execution.number", "3");
+				restartJobParameters.setProperty("step1.stop", "ES.STOP");
+				restartJobParameters.setProperty("step1.next", "ES.STEP1");
+				restartJobParameters.setProperty("step2.fail", "ES.FAIL");
+				restartJobParameters.setProperty("step2.next", "ES.STEP2");
+				Reporter.log("Invoke restartJobAndWaitForResult with executionId: " + execution2.getExecutionId() + "<p>");
 				execution3 = jobOp.restartJobAndWaitForResult(execution2.getExecutionId(),restartJobParameters);
 				Reporter.log("execution #3 JobExecution getBatchStatus()="+execution3.getBatchStatus()+"<p>");
 				Reporter.log("execution #3 JobExecution getExitStatus()="+execution3.getExitStatus()+"<p>");				
-                assertWithMessage("Testing execution #3", BatchStatus.COMPLETED, execution3.getBatchStatus());
-                assertWithMessage("Testing execution #3", "COMPLETED", execution3.getExitStatus());
-            }
-        } catch (Exception e) {
-            handleException(METHOD, e);
-        }
+				assertWithMessage("Testing execution #3", BatchStatus.COMPLETED, execution3.getBatchStatus());
+				assertWithMessage("Testing execution #3", "COMPLETED", execution3.getExitStatus());  
+			}
+		} catch (Exception e) {
+			handleException(METHOD, e);
+		}
 
-    }
+	}
 
-    /*
+	/*
 	 * Obviously would be nicer to have more granular tests for some of this function,
 	 * but here we're going a different route and saying, if it's going to require
 	 * restart it will have some complexity, so let's test a few different functions
 	 * in one longer restart scenario.
-     */
- /*
+	 */
+	/*
 	 * @testName: testAllowStartIfCompleteRestartExecution
 	 * @assertion:    1. @restart attribute on <stop> transition element
 	 *           :    2. tests difference between allow-start-if-complete = true or false (default)
@@ -234,49 +234,49 @@ public class BatchletRestartStateMachineTests extends AbstractTest {
 	 * Note that because we reuse the same batchlet across the three steps we perform some validation in 
 	 * the batchlet, using the stepName and the execution number (as restart parameter), so that we validate we're never called
 	 * in the wrong step in the wrong execution (e.g. in execution.number N we shouldn't be in step S).
-     */
-    @Test
-    @org.junit.Test
-    public void testAllowStartIfCompleteRestartExecution() throws Exception {
+	 */
+	@Test
+	@org.junit.Test
+	public void testAllowStartIfCompleteRestartExecution() throws Exception {
 
-        String METHOD = "testAllowStartIfCompleteRestartExecution";
+		String METHOD = "testAllowStartIfCompleteRestartExecution";
 
-        try {
-            long lastExecutionId = 0L;
-            TCKJobExecutionWrapper exec = null;
+		try {
+			long lastExecutionId = 0L;
+			TCKJobExecutionWrapper exec = null;
 
-            for (int i = 1; i <= 6; i++) {
-                String execString = new Integer(i).toString();
-                Properties jobParameters = new Properties();
-                jobParameters.put("execution.number", execString);
-                if (i == 1) {
-                    Reporter.log("Invoking startJobAndWaitForResult for Execution #1<p>");
-                    exec = jobOp.startJobAndWaitForResult("batchletRestartStateMachine", jobParameters);
-                } else {
-                    Reporter.log("Invoke restartJobAndWaitForResult<p>");
-                    exec = jobOp.restartJobAndWaitForResult(lastExecutionId, jobParameters);
-                }
-                lastExecutionId = exec.getExecutionId();
+			for (int i = 1; i <= 6; i++) {
+				String execString = new Integer(i).toString();
+				Properties jobParameters = new Properties();
+				jobParameters.put("execution.number", execString);
+				if (i == 1) {
+					Reporter.log("Invoking startJobAndWaitForResult for Execution #1<p>");
+					exec = jobOp.startJobAndWaitForResult("batchletRestartStateMachine", jobParameters);
+				} else {
+					Reporter.log("Invoke restartJobAndWaitForResult<p>");
+					exec = jobOp.restartJobAndWaitForResult(lastExecutionId, jobParameters);
+				}
+				lastExecutionId = exec.getExecutionId();
 
 				Reporter.log("Execution #" + i + " JobExecution getBatchStatus()="+exec.getBatchStatus()+"<p>");
 				Reporter.log("Execution #" + i + " JobExecution getExitStatus()="+exec.getExitStatus()+"<p>");
-                if (i == 6) {
-                    assertWithMessage("Testing execution #" + i, BatchStatus.COMPLETED, exec.getBatchStatus());
-                } else {
-                    assertWithMessage("Testing execution #" + i, BatchStatus.STOPPED, exec.getBatchStatus());
-                }
-                assertWithMessage("Testing execution #" + i, "EXECUTION." + execString, exec.getExitStatus());
-            }
-        } catch (Exception e) {
-            handleException(METHOD, e);
-        }
+				if (i == 6) {
+					assertWithMessage("Testing execution #" + i, BatchStatus.COMPLETED, exec.getBatchStatus());
+				} else {
+					assertWithMessage("Testing execution #" + i, BatchStatus.STOPPED, exec.getBatchStatus());
+				}
+				assertWithMessage("Testing execution #" + i, "EXECUTION." + execString, exec.getExitStatus());
+			}
+		} catch (Exception e) {
+			handleException(METHOD, e);
+		}
 
-    }
-
-    private static void handleException(String methodName, Exception e) throws Exception {
+	}
+	
+	private static void handleException(String methodName, Exception e) throws Exception {
 		Reporter.log("Caught exception: " + e.getMessage()+"<p>");
-        Reporter.log(methodName + " failed<p>");
-        throw e;
-    }
+		Reporter.log(methodName + " failed<p>");
+		throw e;
+	}
 
 }

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/BatchletRestartStateMachineTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/BatchletRestartStateMachineTests.java
@@ -22,7 +22,7 @@ import com.ibm.jbatch.tck.tests.AbstractTest;
 import static com.ibm.jbatch.tck.utils.AssertionUtils.assertWithMessage;
 
 import java.util.Properties;
-
+ 
 import javax.batch.runtime.BatchStatus;
 
 import org.junit.BeforeClass;
@@ -55,7 +55,8 @@ public class BatchletRestartStateMachineTests extends AbstractTest {
     }
 
     /* cleanup */
-    public void cleanup() {
+	public void  cleanup()
+	{		
 
     }
 
@@ -135,8 +136,8 @@ public class BatchletRestartStateMachineTests extends AbstractTest {
                 Reporter.log("Invoke startJobAndWaitForResult");
                 execution1 = jobOp.startJobAndWaitForResult("overrideOnAttributeValuesUponRestartBatchlet", jobParams);
 
-                Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-                Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+				Reporter.log("execution #1 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
+				Reporter.log("execution #1 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
                 assertWithMessage("Testing execution #1", BatchStatus.STOPPED, execution1.getBatchStatus());
                 assertWithMessage("Testing execution #1", "STOPPED", execution1.getExitStatus());
             }
@@ -153,9 +154,9 @@ public class BatchletRestartStateMachineTests extends AbstractTest {
                 restartJobParameters.setProperty("step2.fail", "ES.STEP2");
                 restartJobParameters.setProperty("step2.next", "ES.STEP2");
                 Reporter.log("Invoke restartJobAndWaitForResult with executionId: " + execution1.getExecutionId() + "<p>");
-                execution2 = jobOp.restartJobAndWaitForResult(execution1.getExecutionId(), restartJobParameters);
-                Reporter.log("execution #2 JobExecution getBatchStatus()=" + execution2.getBatchStatus() + "<p>");
-                Reporter.log("execution #2 JobExecution getExitStatus()=" + execution2.getExitStatus() + "<p>");
+				execution2 = jobOp.restartJobAndWaitForResult(execution1.getExecutionId(),restartJobParameters);				
+				Reporter.log("execution #2 JobExecution getBatchStatus()="+execution2.getBatchStatus()+"<p>");
+				Reporter.log("execution #2 JobExecution getExitStatus()="+execution2.getExitStatus()+"<p>");
                 assertWithMessage("Testing execution #2", BatchStatus.FAILED, execution2.getBatchStatus());
                 // See JSL snippet above for where "SUCCESS" comes from
                 assertWithMessage("Testing execution #2", EXECUTION2_EXPECTED_EXIT_STATUS_FROM_JSL_ATTRIBUTE, execution2.getExitStatus());
@@ -175,9 +176,9 @@ public class BatchletRestartStateMachineTests extends AbstractTest {
                 restartJobParameters.setProperty("step2.fail", "ES.FAIL");
                 restartJobParameters.setProperty("step2.next", "ES.STEP2");
                 Reporter.log("Invoke restartJobAndWaitForResult with executionId: " + execution2.getExecutionId() + "<p>");
-                execution3 = jobOp.restartJobAndWaitForResult(execution2.getExecutionId(), restartJobParameters);
-                Reporter.log("execution #3 JobExecution getBatchStatus()=" + execution3.getBatchStatus() + "<p>");
-                Reporter.log("execution #3 JobExecution getExitStatus()=" + execution3.getExitStatus() + "<p>");
+				execution3 = jobOp.restartJobAndWaitForResult(execution2.getExecutionId(),restartJobParameters);
+				Reporter.log("execution #3 JobExecution getBatchStatus()="+execution3.getBatchStatus()+"<p>");
+				Reporter.log("execution #3 JobExecution getExitStatus()="+execution3.getExitStatus()+"<p>");				
                 assertWithMessage("Testing execution #3", BatchStatus.COMPLETED, execution3.getBatchStatus());
                 assertWithMessage("Testing execution #3", "COMPLETED", execution3.getExitStatus());
             }
@@ -257,8 +258,8 @@ public class BatchletRestartStateMachineTests extends AbstractTest {
                 }
                 lastExecutionId = exec.getExecutionId();
 
-                Reporter.log("Execution #" + i + " JobExecution getBatchStatus()=" + exec.getBatchStatus() + "<p>");
-                Reporter.log("Execution #" + i + " JobExecution getExitStatus()=" + exec.getExitStatus() + "<p>");
+				Reporter.log("Execution #" + i + " JobExecution getBatchStatus()="+exec.getBatchStatus()+"<p>");
+				Reporter.log("Execution #" + i + " JobExecution getExitStatus()="+exec.getExitStatus()+"<p>");
                 if (i == 6) {
                     assertWithMessage("Testing execution #" + i, BatchStatus.COMPLETED, exec.getBatchStatus());
                 } else {
@@ -273,7 +274,7 @@ public class BatchletRestartStateMachineTests extends AbstractTest {
     }
 
     private static void handleException(String methodName, Exception e) throws Exception {
-        Reporter.log("Caught exception: " + e.getMessage() + "<p>");
+		Reporter.log("Caught exception: " + e.getMessage()+"<p>");
         Reporter.log(methodName + " failed<p>");
         throw e;
     }

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ChunkTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ChunkTests.java
@@ -37,6 +37,7 @@ import com.ibm.jbatch.tck.artifacts.specialized.MyMultipleExceptionsRetryReadLis
 import com.ibm.jbatch.tck.artifacts.specialized.MySkipProcessListener;
 import com.ibm.jbatch.tck.artifacts.specialized.MySkipReadListener;
 import com.ibm.jbatch.tck.artifacts.specialized.MySkipWriteListener;
+import com.ibm.jbatch.tck.tests.AbstractTest;
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
 import com.ibm.jbatch.tck.utils.TCKJobExecutionWrapper;
 
@@ -46,7 +47,7 @@ import org.testng.Reporter;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-public class ChunkTests {
+public class ChunkTests extends AbstractTest {
 
     private static JobOperatorBridge jobOp = null;
 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ContextAndListenerTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ContextAndListenerTests.java
@@ -18,6 +18,7 @@
  */
 package com.ibm.jbatch.tck.tests.jslxml;
 
+import com.ibm.jbatch.tck.tests.AbstractTest;
 import static com.ibm.jbatch.tck.utils.AssertionUtils.assertObjEquals;
 import static com.ibm.jbatch.tck.utils.AssertionUtils.assertWithMessage;
 
@@ -37,7 +38,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-public class ContextAndListenerTests {
+public class ContextAndListenerTests extends AbstractTest {
 
 	private final static Logger logger = Logger.getLogger(ContextAndListenerTests.class.getName());
 	private static JobOperatorBridge jobOp = null;

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ContextsGetIdTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ContextsGetIdTests.java
@@ -32,8 +32,9 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import com.ibm.jbatch.tck.tests.AbstractTest;
 
-public class ContextsGetIdTests {
+public class ContextsGetIdTests extends AbstractTest {
 
 	private JobOperatorBridge jobOp = null;
 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/DeciderTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/DeciderTests.java
@@ -36,8 +36,9 @@ import org.testng.annotations.Test;
 import com.ibm.jbatch.tck.artifacts.common.StatusConstants;
 import com.ibm.jbatch.tck.artifacts.specialized.DeciderTestsBatchlet;
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import com.ibm.jbatch.tck.tests.AbstractTest;
 
-public class DeciderTests implements StatusConstants {
+public class DeciderTests extends AbstractTest implements StatusConstants {
 	private final static Logger logger = Logger.getLogger(DeciderTests.class.getName());
 	private static JobOperatorBridge jobOp = null;
 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ExecuteTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ExecuteTests.java
@@ -28,13 +28,14 @@ import javax.batch.runtime.JobExecution;
 
 import com.ibm.jbatch.tck.artifacts.specialized.BatchletUsingStepContextImpl;
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import com.ibm.jbatch.tck.tests.AbstractTest;
 
 import org.junit.BeforeClass;
 import org.testng.Reporter;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-public class ExecuteTests {
+public class ExecuteTests extends AbstractTest {
 
 	private final static Logger logger = Logger.getLogger(ExecuteTests.class.getName());
 	private static JobOperatorBridge jobOp = null;

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ExecutionTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ExecutionTests.java
@@ -28,6 +28,7 @@ import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.JobExecution;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import com.ibm.jbatch.tck.tests.AbstractTest;
 
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -36,7 +37,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-public class ExecutionTests {
+public class ExecutionTests extends AbstractTest {
 
 	private final static Logger logger = Logger.getLogger(ExecutionTests.class.getName());
 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/FlowTransitioningTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/FlowTransitioningTests.java
@@ -35,8 +35,9 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import com.ibm.jbatch.tck.tests.AbstractTest;
 
-public class FlowTransitioningTests {
+public class FlowTransitioningTests extends AbstractTest {
 
 	private JobOperatorBridge jobOp = null;
 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/JobAttributeRestartTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/JobAttributeRestartTests.java
@@ -32,6 +32,7 @@ import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.JobExecution;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import com.ibm.jbatch.tck.tests.AbstractTest;
 
 import org.junit.Before;
 import org.testng.Reporter;
@@ -39,7 +40,7 @@ import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-public class JobAttributeRestartTests {
+public class JobAttributeRestartTests extends AbstractTest {
 
 	private JobOperatorBridge jobOp = null;
 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/JobExecutableSequenceTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/JobExecutableSequenceTests.java
@@ -35,8 +35,9 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import com.ibm.jbatch.tck.tests.AbstractTest;
 
-public class JobExecutableSequenceTests {
+public class JobExecutableSequenceTests extends AbstractTest {
 
 	private JobOperatorBridge jobOp = null;
 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/JobLevelPropertiesTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/JobLevelPropertiesTests.java
@@ -28,6 +28,7 @@ import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.JobExecution;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import com.ibm.jbatch.tck.tests.AbstractTest;
 
 import org.junit.Before;
 import org.testng.Reporter;
@@ -35,7 +36,7 @@ import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-public class JobLevelPropertiesTests {
+public class JobLevelPropertiesTests extends AbstractTest {
 
 	private JobOperatorBridge jobOp = null;
 	

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/JobOperatorTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/JobOperatorTests.java
@@ -18,6 +18,7 @@
  */
 package com.ibm.jbatch.tck.tests.jslxml;
 
+import com.ibm.jbatch.tck.tests.AbstractTest;
 import static com.ibm.jbatch.tck.utils.AssertionUtils.assertObjEquals;
 import static com.ibm.jbatch.tck.utils.AssertionUtils.assertWithMessage;
 
@@ -44,7 +45,7 @@ import org.testng.annotations.Test;
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
 import com.ibm.jbatch.tck.utils.TCKJobExecutionWrapper;
 
-public class JobOperatorTests {
+public class JobOperatorTests extends AbstractTest {
 
 	private final static Logger logger = Logger.getLogger(JobOperatorTests.class.getName());
 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ListenerOnErrorTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ListenerOnErrorTests.java
@@ -32,9 +32,10 @@ import org.testng.annotations.Test;
 
 import com.ibm.jbatch.tck.ann.*;
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import com.ibm.jbatch.tck.tests.AbstractTest;
 
 
-public class ListenerOnErrorTests {
+public class ListenerOnErrorTests extends AbstractTest {
 	private static JobOperatorBridge jobOp = null;
 	
 	@BeforeMethod

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/MetricsTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/MetricsTests.java
@@ -36,8 +36,9 @@ import org.testng.annotations.Test;
 
 import com.ibm.jbatch.tck.artifacts.specialized.MetricsStepListener;
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import com.ibm.jbatch.tck.tests.AbstractTest;
 
-public class MetricsTests {
+public class MetricsTests extends AbstractTest {
 
 	private static JobOperatorBridge jobOp = null;
 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ParallelContextPropagationTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ParallelContextPropagationTests.java
@@ -28,6 +28,7 @@ import javax.batch.runtime.StepExecution;
 
 import com.ibm.jbatch.tck.ann.*;
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import com.ibm.jbatch.tck.tests.AbstractTest;
 
 import org.junit.Before;
 import org.testng.Reporter;
@@ -36,7 +37,7 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 
-public class ParallelContextPropagationTests {
+public class ParallelContextPropagationTests extends AbstractTest {
 
 	private static JobOperatorBridge jobOp = null;
 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ParallelExecutionTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ParallelExecutionTests.java
@@ -39,9 +39,10 @@ import org.testng.annotations.Test;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
 import com.ibm.jbatch.tck.utils.TCKJobExecutionWrapper;
+import com.ibm.jbatch.tck.tests.AbstractTest;
 
 
-public class ParallelExecutionTests {
+public class ParallelExecutionTests extends AbstractTest {
 
 	private final static Logger logger = Logger.getLogger(ParallelExecutionTests.class.getName());
 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/PartitionRerunTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/PartitionRerunTests.java
@@ -35,8 +35,9 @@ import org.testng.annotations.Test;
 
 import com.ibm.jbatch.tck.ann.*;
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import com.ibm.jbatch.tck.tests.AbstractTest;
 
-public class PartitionRerunTests {
+public class PartitionRerunTests extends AbstractTest {
 	static JobOperatorBridge jobOp = null;
 
 	private static void handleException(String methodName, Exception e) throws Exception {

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/PropertySubstitutionTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/PropertySubstitutionTests.java
@@ -26,6 +26,7 @@ import java.util.Properties;
 import javax.batch.runtime.JobExecution;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import com.ibm.jbatch.tck.tests.AbstractTest;
 
 import org.junit.BeforeClass;
 import org.testng.Reporter;
@@ -33,7 +34,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-public class PropertySubstitutionTests {
+public class PropertySubstitutionTests extends AbstractTest {
 
 	private static JobOperatorBridge jobOp;
 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/RestartNotMostRecentTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/RestartNotMostRecentTests.java
@@ -32,8 +32,9 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import com.ibm.jbatch.tck.tests.AbstractTest;
 
-public class RestartNotMostRecentTests {
+public class RestartNotMostRecentTests extends AbstractTest {
 	
 	private JobOperatorBridge jobOp = null;
 	

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/RetryListenerTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/RetryListenerTests.java
@@ -26,13 +26,14 @@ import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.JobExecution;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import com.ibm.jbatch.tck.tests.AbstractTest;
 
 import org.junit.BeforeClass;
 import org.testng.Reporter;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-public class RetryListenerTests {
+public class RetryListenerTests extends AbstractTest {
 
 	private static JobOperatorBridge jobOp = null;
 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/SplitFlowTransitionLoopTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/SplitFlowTransitionLoopTests.java
@@ -32,8 +32,9 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import com.ibm.jbatch.tck.tests.AbstractTest;
 
-public class SplitFlowTransitionLoopTests {
+public class SplitFlowTransitionLoopTests extends AbstractTest {
 
 	private JobOperatorBridge jobOp = null;
 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/SplitTransitioningTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/SplitTransitioningTests.java
@@ -35,8 +35,9 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import com.ibm.jbatch.tck.tests.AbstractTest;
 
-public class SplitTransitioningTests {
+public class SplitTransitioningTests extends AbstractTest {
 
 	private JobOperatorBridge jobOp = null;
 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/StartLimitTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/StartLimitTests.java
@@ -34,8 +34,9 @@ import org.testng.annotations.Test;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
 import com.ibm.jbatch.tck.utils.TCKJobExecutionWrapper;
+import com.ibm.jbatch.tck.tests.AbstractTest;
 
-public class StartLimitTests {
+public class StartLimitTests extends AbstractTest {
 
 	private JobOperatorBridge jobOp = null;
 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/StepExecutionTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/StepExecutionTests.java
@@ -36,6 +36,7 @@ import javax.batch.runtime.StepExecution;
 import com.ibm.jbatch.tck.artifacts.reusable.MyBatchletImpl;
 import com.ibm.jbatch.tck.artifacts.reusable.MyPersistentUserData;
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import com.ibm.jbatch.tck.tests.AbstractTest;
 
 import org.junit.BeforeClass;
 import org.testng.Reporter;
@@ -43,7 +44,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-public class StepExecutionTests {
+public class StepExecutionTests extends AbstractTest {
 
 	private final static Logger logger = Logger.getLogger(StepExecutionTests.class.getName());
 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/StepLevelPropertiesTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/StepLevelPropertiesTests.java
@@ -28,6 +28,7 @@ import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.JobExecution;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import com.ibm.jbatch.tck.tests.AbstractTest;
 
 import org.junit.Before;
 import org.testng.Reporter;
@@ -35,7 +36,7 @@ import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-public class StepLevelPropertiesTests {
+public class StepLevelPropertiesTests extends AbstractTest {
 
 	private JobOperatorBridge jobOp = null;
 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/StopOrFailOnExitStatusWithRestartTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/StopOrFailOnExitStatusWithRestartTests.java
@@ -33,8 +33,9 @@ import org.testng.annotations.Test;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
 import com.ibm.jbatch.tck.utils.TCKJobExecutionWrapper;
+import com.ibm.jbatch.tck.tests.AbstractTest;
 
-public class StopOrFailOnExitStatusWithRestartTests {
+public class StopOrFailOnExitStatusWithRestartTests extends AbstractTest {
 
 	private static JobOperatorBridge jobOp;
 

--- a/jakarta.batch.official.tck/otherFiles/how-to-run-tck-against-jbatch-script.sh
+++ b/jakarta.batch.official.tck/otherFiles/how-to-run-tck-against-jbatch-script.sh
@@ -18,10 +18,13 @@ set -x
 ################
 
 # 1. Root location of TCK execution - Also useful for holding this script itself, and its output logs
-TCK_HOME_DIR=~/jkbatch/
+#TCK_HOME_DIR=~/jkbatch/
+TCK_HOME_DIR="/home/omihalyi/workspaces/JakartaEE/Jakarta EE specs/Batch/batch-tck-run"
+TCK_SRC_DIR="/home/omihalyi/workspaces/JakartaEE/Jakarta EE specs/Batch/batch-tck"
 
 # 2. Point to JAVA_HOME so that the signature test command below can find the runtime JAR (rt.jar):
-export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.212.b04-0.el7_6.x86_64/jre/
+#export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.212.b04-0.el7_6.x86_64/jre/
+export JAVA_HOME=/home/omihalyi/.sdkman/candidates/java/8.0.232-zulu/jre
 
 #------------------------------------------------------------------------------------------------------
 # NOTE: Since these are Maven coordinates of already-released artifacts, we take the shortcut of
@@ -34,11 +37,11 @@ export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.212.b04-0.el7_6.x86_64/jr
 #------------------------------------------------------------------------------------------------------
 # 3. Copy required JARs obtained via other mechanisms
 REQUIRED_JARS="\
- /home/ibmadmin/.m2/repository/org/apache/derby/derby/10.10.1.1/derby-10.10.1.1.jar \
- /home/ibmadmin/.m2/repository/com/ibm/jbatch/com.ibm.jbatch.container/1.0.3/com.ibm.jbatch.container-1.0.3.jar \
- /home/ibmadmin/.m2/repository/com/ibm/jbatch/com.ibm.jbatch.spi/1.0.3/com.ibm.jbatch.spi-1.0.3.jar \
- /home/ibmadmin/.m2/repository/net/java/sigtest/sigtestdev/3.0-b12-v20140219/sigtestdev-3.0-b12-v20140219.jar \
- /home/ibmadmin/.m2/repository/jakarta/batch/jakarta.batch-api/1.0.2/jakarta.batch-api-1.0.2.jar \
+ /home/omihalyi/.m2/repository/org/apache/derby/derby/10.10.1.1/derby-10.10.1.1.jar \
+ /home/omihalyi/.m2/repository/com/ibm/jbatch/com.ibm.jbatch.container/1.0.3/com.ibm.jbatch.container-1.0.3.jar \
+ /home/omihalyi/.m2/repository/com/ibm/jbatch/com.ibm.jbatch.spi/1.0.3/com.ibm.jbatch.spi-1.0.3.jar \
+ /home/omihalyi/.m2/repository/net/java/sigtest/sigtestdev/3.0-b12-v20140219/sigtestdev-3.0-b12-v20140219.jar \
+ /home/omihalyi/.m2/repository/jakarta/batch/jakarta.batch-api/1.0.2/jakarta.batch-api-1.0.2.jar \
 "
 
 #--------------------------------------------------
@@ -73,14 +76,15 @@ TCK_DOWNLOAD_URL=https://download.eclipse.org/jakartaee/batch/1.0/eclipse-batch-
 ################
 # DON'T CHANGE
 ################
-cd $TCK_HOME_DIR
+cd "$TCK_HOME_DIR"
 
 #
 # get TCK zip into an empty directory
 #
 rm -rf tckdir; mkdir tckdir; cd tckdir
 ls -la .
-wget $TCK_DOWNLOAD_URL
+#wget $TCK_DOWNLOAD_URL
+cp "$TCK_SRC_DIR/jakarta.batch.official.tck/target/jakarta.batch.official.tck-1.0.2.zip" .
 
 #
 # copy prereqs into an empty directory

--- a/jakarta.batch.official.tck/otherFiles/how-to-run-tck-against-jbatch-script.sh
+++ b/jakarta.batch.official.tck/otherFiles/how-to-run-tck-against-jbatch-script.sh
@@ -18,13 +18,10 @@ set -x
 ################
 
 # 1. Root location of TCK execution - Also useful for holding this script itself, and its output logs
-#TCK_HOME_DIR=~/jkbatch/
-TCK_HOME_DIR="/home/omihalyi/workspaces/JakartaEE/Jakarta EE specs/Batch/batch-tck-run"
-TCK_SRC_DIR="/home/omihalyi/workspaces/JakartaEE/Jakarta EE specs/Batch/batch-tck"
+TCK_HOME_DIR=~/jkbatch/
 
 # 2. Point to JAVA_HOME so that the signature test command below can find the runtime JAR (rt.jar):
-#export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.212.b04-0.el7_6.x86_64/jre/
-export JAVA_HOME=/home/omihalyi/.sdkman/candidates/java/8.0.232-zulu/jre
+export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.212.b04-0.el7_6.x86_64/jre/
 
 #------------------------------------------------------------------------------------------------------
 # NOTE: Since these are Maven coordinates of already-released artifacts, we take the shortcut of
@@ -37,11 +34,11 @@ export JAVA_HOME=/home/omihalyi/.sdkman/candidates/java/8.0.232-zulu/jre
 #------------------------------------------------------------------------------------------------------
 # 3. Copy required JARs obtained via other mechanisms
 REQUIRED_JARS="\
- /home/omihalyi/.m2/repository/org/apache/derby/derby/10.10.1.1/derby-10.10.1.1.jar \
- /home/omihalyi/.m2/repository/com/ibm/jbatch/com.ibm.jbatch.container/1.0.3/com.ibm.jbatch.container-1.0.3.jar \
- /home/omihalyi/.m2/repository/com/ibm/jbatch/com.ibm.jbatch.spi/1.0.3/com.ibm.jbatch.spi-1.0.3.jar \
- /home/omihalyi/.m2/repository/net/java/sigtest/sigtestdev/3.0-b12-v20140219/sigtestdev-3.0-b12-v20140219.jar \
- /home/omihalyi/.m2/repository/jakarta/batch/jakarta.batch-api/1.0.2/jakarta.batch-api-1.0.2.jar \
+ /home/ibmadmin/.m2/repository/org/apache/derby/derby/10.10.1.1/derby-10.10.1.1.jar \
+ /home/ibmadmin/.m2/repository/com/ibm/jbatch/com.ibm.jbatch.container/1.0.3/com.ibm.jbatch.container-1.0.3.jar \
+ /home/ibmadmin/.m2/repository/com/ibm/jbatch/com.ibm.jbatch.spi/1.0.3/com.ibm.jbatch.spi-1.0.3.jar \
+ /home/ibmadmin/.m2/repository/net/java/sigtest/sigtestdev/3.0-b12-v20140219/sigtestdev-3.0-b12-v20140219.jar \
+ /home/ibmadmin/.m2/repository/jakarta/batch/jakarta.batch-api/1.0.2/jakarta.batch-api-1.0.2.jar \
 "
 
 #--------------------------------------------------
@@ -76,15 +73,14 @@ TCK_DOWNLOAD_URL=https://download.eclipse.org/jakartaee/batch/1.0/eclipse-batch-
 ################
 # DON'T CHANGE
 ################
-cd "$TCK_HOME_DIR"
+cd $TCK_HOME_DIR
 
 #
 # get TCK zip into an empty directory
 #
 rm -rf tckdir; mkdir tckdir; cd tckdir
 ls -la .
-#wget $TCK_DOWNLOAD_URL
-cp "$TCK_SRC_DIR/jakarta.batch.official.tck/target/jakarta.batch.official.tck-1.0.2.zip" .
+wget $TCK_DOWNLOAD_URL
 
 #
 # copy prereqs into an empty directory

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <!-- Dependencies -->
         <version.jakarta.enterprise.jakarta.enterprise.cdi-api>2.0.1</version.jakarta.enterprise.jakarta.enterprise.cdi-api>
         <version.jakarta.inject.jakarta.inject-api>1.0</version.jakarta.inject.jakarta.inject-api>
-        <version.org.testng.testng>6.8.8</version.org.testng.testng>
+        <version.org.testng.testng>6.14.3</version.org.testng.testng>
         <version.com.beust.jcommander>1.60</version.com.beust.jcommander>
         <version.org.sonatype.plugins.nexus-staging-maven-plugin>1.6.6</version.org.sonatype.plugins.nexus-staging-maven-plugin>
         <version.com.mycila.maven-license-plugin.maven-license-plugin>1.10.b1</version.com.mycila.maven-license-plugin.maven-license-plugin>


### PR DESCRIPTION
Adds support for running TCK tests in a Java application container using Arquillian. It also modifies the example TCK runner for JBatch to use an Arquillian Weld embedded container instead of plain Weld to run the tests in the Weld container.

There's also an example of running the TCK using Arquillian against a locally installed Payara Server: https://github.com/OndroMih/Payara-Batch-TCK-Runner/tree/poc-arquillian. This wouldn't be possible without changes in this pull request.