### PR TITLE
Convert tests to JUnit 5

### DIFF
--- a/com.ibm.jbatch.tck.exec/pom.xml
+++ b/com.ibm.jbatch.tck.exec/pom.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2012 International Business Machines Corp.
+   Copyright 2012 International Business Machines Corp.
 
-  See the NOTICE file distributed with this work for additional information
-  regarding copyright ownership. Licensed under the Apache License,
-  Version 2.0 (the "License"); you may not use this file except in compliance
-  with the License. You may obtain a copy of the License at
+   See the NOTICE file distributed with this work for additional information
+   regarding copyright ownership. Licensed under the Apache License,
+   Version 2.0 (the "License"); you may not use this file except in compliance
+   with the License. You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 
-  SPDX-License-Identifier: Apache-2.0
--->
+   SPDX-License-Identifier: Apache-2.0
+ -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/com.ibm.jbatch.tck.exec/pom.xml
+++ b/com.ibm.jbatch.tck.exec/pom.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright 2012 International Business Machines Corp.
+  Copyright 2012 International Business Machines Corp.
 
-   See the NOTICE file distributed with this work for additional information
-   regarding copyright ownership. Licensed under the Apache License,
-   Version 2.0 (the "License"); you may not use this file except in compliance
-   with the License. You may obtain a copy of the License at
+  See the NOTICE file distributed with this work for additional information
+  regarding copyright ownership. Licensed under the Apache License,
+  Version 2.0 (the "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 
-   SPDX-License-Identifier: Apache-2.0
- -->
+  SPDX-License-Identifier: Apache-2.0
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -35,10 +35,10 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
-        </dependency>
+        </dependency>        
         <dependency>
             <groupId>jakarta.batch</groupId>
             <artifactId>jakarta.batch-api</artifactId>
@@ -134,7 +134,7 @@
                             <groupId>jakarta.batch</groupId>
                             <artifactId>com.ibm.jbatch.tck</artifactId>
                             <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
-                            <includes>testng/*</includes>
+                            <includes>testprofiles/*</includes>
                         </artifactItem>
                     </artifactItems>
                 </configuration>
@@ -142,7 +142,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${version.org.apache.maven.plugins.maven-failsafe-plugin}</version>
                 <executions>
                     <execution>
                         <id>integration-test</id>
@@ -150,14 +149,11 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
-                            <suiteXmlFiles>
-                                <!-- Not sure how to reference the suite XML file within the dependency artifact, so rely on an unpacking first.-->
-                                <suiteXmlFile>${project.build.directory}/test-classes/testng/batch-tck-impl-SE-suite.xml</suiteXmlFile>
-                                <!-- For debugging -->
-                                <!--
-                                <suiteXmlFile>${project.basedir}/testng.suite.xml</suiteXmlFile>
--->
-                            </suiteXmlFiles>
+                            <dependenciesToScan>
+                                <dependency>jakarta.batch:com.ibm.jbatch.tck</dependency>
+                            </dependenciesToScan>
+                            <includesFile>${project.build.directory}/test-classes/testprofiles/batch-tck-impl-SE-suite-includes.txt</includesFile>
+                            <excludesFile>${project.build.directory}/test-classes/testprofiles/batch-tck-impl-SE-suite-excludes.txt</excludesFile>
                             <systemPropertiesFile>${project.basedir}/test.properties</systemPropertiesFile>
                         </configuration>
                     </execution>

--- a/com.ibm.jbatch.tck.exec/pom.xml
+++ b/com.ibm.jbatch.tck.exec/pom.xml
@@ -35,11 +35,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>        
-        <dependency>
             <groupId>jakarta.batch</groupId>
             <artifactId>jakarta.batch-api</artifactId>
             <scope>test</scope>

--- a/com.ibm.jbatch.tck/pom.xml
+++ b/com.ibm.jbatch.tck/pom.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2012 International Business Machines Corp.
+   Copyright 2012 International Business Machines Corp.
 
-  See the NOTICE file distributed with this work for additional information
-  regarding copyright ownership. Licensed under the Apache License,
-  Version 2.0 (the "License"); you may not use this file except in compliance
-  with the License. You may obtain a copy of the License at
+   See the NOTICE file distributed with this work for additional information
+   regarding copyright ownership. Licensed under the Apache License,
+   Version 2.0 (the "License"); you may not use this file except in compliance
+   with the License. You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 
-  SPDX-License-Identifier: Apache-2.0
--->
+   SPDX-License-Identifier: Apache-2.0
+ -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>jakarta.batch</groupId>
@@ -109,9 +109,9 @@
                             </configuration>
                         </execution>
                         <!-- By failing when the newly-generated batch.xml changes, we force someone to review
-                        the changes.   We purposely don't want to make it too easy to introduce a change here, 
-                        since this will ultimately affect the pass/failing of implementations' runs against the TCK.
-                        This will add as a guard that the person who would make the update knows what they're doing. -->
+                             the changes.   We purposely don't want to make it too easy to introduce a change here, 
+                             since this will ultimately affect the pass/failing of implementations' runs against the TCK.
+                             This will add as a guard that the person who would make the update knows what they're doing. -->
                         <execution>
                             <id>generate-batch.xml</id>
                             <goals>
@@ -147,8 +147,8 @@
                             </configuration>
                         </execution>
                         <!-- Updating the signature files should not be done lightly.  This changes the specified, public API. 
-                        We purposely make this fail by default when a signature is changed, to ensure
-                        that the person who would make the update knows what they're doing. -->
+                             We purposely make this fail by default when a signature is changed, to ensure
+                             that the person who would make the update knows what they're doing. -->
                         <execution>
                             <id>generate-sigtest</id>
                             <goals>
@@ -158,8 +158,8 @@
                             <configuration>
                                 <target>
                                     <!-- Note this simply uses the JRE level of the JRE executing Maven and generates the correspondng .sig file.
-                                    So to generate the Java 6, 7, 8 .sig files you have to actually run Maven using Java 6, 7, 8, respectively, 
-                                    once for each.  You can't just generate them all at once. -->
+                                         So to generate the Java 6, 7, 8 .sig files you have to actually run Maven using Java 6, 7, 8, respectively, 
+                                         once for each.  You can't just generate them all at once. -->
                                     <condition property="jdk" value="6">
                                         <contains string="${ant.java.version}" substring="1.6"/>
                                     </condition>
@@ -232,13 +232,13 @@
                     </archive>
                 </configuration>
             </plugin>
-            <plugin>
+              <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <skipTests>true</skipTests>
+                      <skipTests>true</skipTests>
                 </configuration>
-            </plugin>
+              </plugin>
         </plugins>
     </build>
     <profiles>
@@ -265,9 +265,7 @@
             <id>batchXML</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
-                <property>
-                    <name>batchXML</name>
-                </property>
+                <property><name>batchXML</name></property>
             </activation>
             <build>
                 <plugins>
@@ -288,9 +286,7 @@
             <id>sigtest</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
-                <property>
-                    <name>sigtest</name>
-                </property>
+                <property><name>sigtest</name></property>
             </activation>
             <build>
                 <plugins>

--- a/com.ibm.jbatch.tck/pom.xml
+++ b/com.ibm.jbatch.tck/pom.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright 2012 International Business Machines Corp.
+  Copyright 2012 International Business Machines Corp.
 
-   See the NOTICE file distributed with this work for additional information
-   regarding copyright ownership. Licensed under the Apache License,
-   Version 2.0 (the "License"); you may not use this file except in compliance
-   with the License. You may obtain a copy of the License at
+  See the NOTICE file distributed with this work for additional information
+  regarding copyright ownership. Licensed under the Apache License,
+  Version 2.0 (the "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 
-   SPDX-License-Identifier: Apache-2.0
- -->
+  SPDX-License-Identifier: Apache-2.0
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>jakarta.batch</groupId>
@@ -34,14 +34,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-        </dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>        
         <dependency>
             <groupId>jakarta.batch</groupId>
             <artifactId>jakarta.batch-api</artifactId>
@@ -114,9 +109,9 @@
                             </configuration>
                         </execution>
                         <!-- By failing when the newly-generated batch.xml changes, we force someone to review
-                             the changes.   We purposely don't want to make it too easy to introduce a change here, 
-                             since this will ultimately affect the pass/failing of implementations' runs against the TCK.
-                             This will add as a guard that the person who would make the update knows what they're doing. -->
+                        the changes.   We purposely don't want to make it too easy to introduce a change here, 
+                        since this will ultimately affect the pass/failing of implementations' runs against the TCK.
+                        This will add as a guard that the person who would make the update knows what they're doing. -->
                         <execution>
                             <id>generate-batch.xml</id>
                             <goals>
@@ -152,8 +147,8 @@
                             </configuration>
                         </execution>
                         <!-- Updating the signature files should not be done lightly.  This changes the specified, public API. 
-                             We purposely make this fail by default when a signature is changed, to ensure
-                             that the person who would make the update knows what they're doing. -->
+                        We purposely make this fail by default when a signature is changed, to ensure
+                        that the person who would make the update knows what they're doing. -->
                         <execution>
                             <id>generate-sigtest</id>
                             <goals>
@@ -163,8 +158,8 @@
                             <configuration>
                                 <target>
                                     <!-- Note this simply uses the JRE level of the JRE executing Maven and generates the correspondng .sig file.
-                                         So to generate the Java 6, 7, 8 .sig files you have to actually run Maven using Java 6, 7, 8, respectively, 
-                                         once for each.  You can't just generate them all at once. -->
+                                    So to generate the Java 6, 7, 8 .sig files you have to actually run Maven using Java 6, 7, 8, respectively, 
+                                    once for each.  You can't just generate them all at once. -->
                                     <condition property="jdk" value="6">
                                         <contains string="${ant.java.version}" substring="1.6"/>
                                     </condition>
@@ -237,13 +232,13 @@
                     </archive>
                 </configuration>
             </plugin>
-              <plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                      <skipTests>true</skipTests>
+                    <skipTests>true</skipTests>
                 </configuration>
-              </plugin>
+            </plugin>
         </plugins>
     </build>
     <profiles>
@@ -270,7 +265,9 @@
             <id>batchXML</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
-                <property><name>batchXML</name></property>
+                <property>
+                    <name>batchXML</name>
+                </property>
             </activation>
             <build>
                 <plugins>
@@ -291,7 +288,9 @@
             <id>sigtest</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
-                <property><name>sigtest</name></property>
+                <property>
+                    <name>sigtest</name>
+                </property>
             </activation>
             <build>
                 <plugins>

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/chunkartifacts/NumbersReader.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/chunkartifacts/NumbersReader.java
@@ -33,8 +33,6 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.sql.DataSource;
 
-import org.testng.Reporter;
-
 import com.ibm.jbatch.tck.artifacts.chunktypes.NumbersCheckpointData;
 import com.ibm.jbatch.tck.artifacts.chunktypes.NumbersRecord;
 import com.ibm.jbatch.tck.artifacts.reusable.MyParentException;
@@ -94,19 +92,19 @@ public class NumbersReader extends AbstractItemReader {
 			    forcedFailCount = 0;
 			    failindex = readerIndex;
 			    testState = STATE_RETRY;
-			    Reporter.log("Fail on purpose NumbersRecord.readItem<p>");
+			    logger.warning("Fail on purpose NumbersRecord.readItem<p>");
 				throw new MyParentException("Fail on purpose in NumbersRecord.readItem()");	
 		} 
 		
 		if (testState == STATE_RETRY)
 		{
 			if(stepCtx.getProperties().getProperty("retry.read.exception.invoked") != "true") {
-				Reporter.log("onRetryReadException not invoked<p>");
+				logger.warning("onRetryReadException not invoked<p>");
 				throw new Exception("onRetryReadException not invoked");
 			}
 			
 			if(stepCtx.getProperties().getProperty("retry.read.exception.match") != "true") {
-				Reporter.log("retryable exception does not match");
+				logger.warning("retryable exception does not match");
 				throw new Exception("retryable exception does not match");
 			}
 			

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/chunkartifacts/RetryProcessor.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/chunkartifacts/RetryProcessor.java
@@ -25,16 +25,17 @@ import javax.batch.api.chunk.ItemProcessor;
 import javax.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
-import org.testng.Reporter;
-
 import com.ibm.jbatch.tck.artifacts.chunktypes.NumbersRecord;
 import com.ibm.jbatch.tck.artifacts.reusable.MyParentException;
+import java.util.logging.Logger;
 
 
 @javax.inject.Named("retryProcessor")
 public class RetryProcessor implements ItemProcessor {
 	
-	
+    private static final String CLASSNAME = RetryProcessor.class.getName();
+    private final static Logger logger = Logger.getLogger(CLASSNAME);
+
     @Inject
     StepContext stepCtx;
 	
@@ -65,8 +66,8 @@ public class RetryProcessor implements ItemProcessor {
 	public NumbersRecord processItem(Object record) throws Exception {
 		int item = ((NumbersRecord)record).getItem();
 		int quantity = ((NumbersRecord)record).getQuantity();
-		Reporter.log("Processing item: " + item + "...<br>");
-		Reporter.log("Processing quantity: " + quantity + "...<p>");
+		logger.info("Processing item: " + item + "...<br>");
+		logger.info("Processing quantity: " + quantity + "...<p>");
 		
 		if(!isInited) {
 			forcedFailCount = Integer.parseInt(forcedFailCountProp);
@@ -79,53 +80,53 @@ public class RetryProcessor implements ItemProcessor {
 				   //forcedFailCount = 0;
 					failindex = count;
 					testState = STATE_RETRY;
-					Reporter.log("Fail on purpose in NumbersRecord.processItem<p>");
+					logger.info("Fail on purpose in NumbersRecord.processItem<p>");
 					throw new MyParentException("Fail on purpose in NumbersRecord.processItem()");	
 		} else if (forcedFailCount != 0 && (count >= forcedFailCount) && (testState == STATE_EXCEPTION)) {
 			failindex = count;
 			testState = STATE_SKIP;
 			forcedFailCount = 0;
-			Reporter.log("Test skip -- Fail on purpose NumbersRecord.readItem<p>");
+			logger.info("Test skip -- Fail on purpose NumbersRecord.readItem<p>");
 			throw new MyParentException("Test skip -- Fail on purpose in NumbersRecord.readItem()");	
 		}
 		
 		if (testState == STATE_RETRY)
 		{
 			if (((Properties)stepCtx.getTransientUserData()).getProperty("retry.process.exception.invoked") != "true") {
-				Reporter.log("onRetryProcessException not invoked<p>");
+				logger.info("onRetryProcessException not invoked<p>");
 				throw new Exception("onRetryProcessException not invoked");
 			} else {
-				Reporter.log("onRetryProcessException was invoked<p>");
+				logger.info("onRetryProcessException was invoked<p>");
 			}
 			
 			if (((Properties)stepCtx.getTransientUserData()).getProperty("retry.process.exception.match") != "true") {
-				Reporter.log("retryable exception does not match<p>");
+				logger.info("retryable exception does not match<p>");
 				throw new Exception("retryable exception does not match");
 			} else {
-				Reporter.log("retryable exception matches<p>");
+				logger.info("retryable exception matches<p>");
 			}
 			
 			testState = STATE_EXCEPTION;
 		} else if(testState == STATE_SKIP) {
 			if (((Properties)stepCtx.getTransientUserData()).getProperty("skip.process.item.invoked") != "true") {
-				Reporter.log("onSkipProcessItem not invoked<p>");
+				logger.info("onSkipProcessItem not invoked<p>");
 				throw new Exception("onSkipProcessItem not invoked");
 			} else {
-				Reporter.log("onSkipProcessItem was invoked<p>");
+				logger.info("onSkipProcessItem was invoked<p>");
 			}
 			
 			if (((Properties)stepCtx.getTransientUserData()).getProperty("skip.process.item.match") != "true") {
-				Reporter.log("skippable exception does not match<p>");
+				logger.info("skippable exception does not match<p>");
 				throw new Exception("skippable exception does not match");
 			} else {
-				Reporter.log("skippable exception matches<p>");
+				logger.info("skippable exception matches<p>");
 			}
 			testState = STATE_NORMAL;
 		}
 		
 		
 		quantity = quantity + 1;
-		Reporter.log("Process [item: " + item + " -- new quantity: " + quantity + "]<p>");
+		logger.info("Process [item: " + item + " -- new quantity: " + quantity + "]<p>");
 		count++;
 		
 		return new NumbersRecord(item, quantity);

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/chunkartifacts/RetryReader.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/chunkartifacts/RetryReader.java
@@ -34,8 +34,6 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.sql.DataSource;
 
-import org.testng.Reporter;
-
 import com.ibm.jbatch.tck.artifacts.chunktypes.NumbersCheckpointData;
 import com.ibm.jbatch.tck.artifacts.chunktypes.NumbersRecord;
 import com.ibm.jbatch.tck.artifacts.reusable.MyParentException;
@@ -100,21 +98,21 @@ public class RetryReader extends AbstractItemReader {
 	public NumbersRecord readItem() throws Exception {
 		int i = readerIndex;
 		
-		Reporter.log("Reading item: " + readerIndex + "...<br>");
+		logger.info("Reading item: " + readerIndex + "...<br>");
 
 		// Throw an exception when forcedFailCount is reached
 		if (forcedFailCount != 0 && (readerIndex >= forcedFailCount) && (testState == STATE_NORMAL)) {
 			    //forcedFailCount = 0;
 			    failindex = readerIndex;
 			    testState = STATE_RETRY;
-			    Reporter.log("Fail on purpose NumbersRecord.readItem<p>");
+			    logger.info("Fail on purpose NumbersRecord.readItem<p>");
 				throw new MyParentException("Fail on purpose in NumbersRecord.readItem()");	
 				
 		} else if (forcedFailCount != 0 && (readerIndex >= forcedFailCount) && (testState == STATE_EXCEPTION)) {
 			failindex = readerIndex;
 			testState = STATE_SKIP;
 			forcedFailCount = 0;
-			Reporter.log("Test skip -- Fail on purpose NumbersRecord.readItem<p>");
+			logger.info("Test skip -- Fail on purpose NumbersRecord.readItem<p>");
 			throw new MyParentException("Test skip -- Fail on purpose in NumbersRecord.readItem()");	
 		}
 		
@@ -137,35 +135,33 @@ public class RetryReader extends AbstractItemReader {
 			}*/
 			
 			if (((Properties)stepCtx.getTransientUserData()).getProperty("retry.read.exception.invoked") != "true") {
-				Reporter.log("onRetryReadException not invoked<p>");
+				logger.info("onRetryReadException not invoked<p>");
 				throw new Exception("onRetryReadException not invoked");
 			} else {
-				Reporter.log("onRetryReadException was invoked<p>");
+				logger.info("onRetryReadException was invoked<p>");
 			}
 			
 			if (((Properties)stepCtx.getTransientUserData()).getProperty("retry.read.exception.match") != "true") {
-				Reporter.log("retryable exception does not match<p>");
+				logger.info("retryable exception does not match<p>");
 				throw new Exception("retryable exception does not match");
 			} else {
-				Reporter.log("Retryable exception matches<p>");
+				logger.info("Retryable exception matches<p>");
 			}
 			testState = STATE_EXCEPTION;
-			//Reporter.log("Test skip after retry -- Fail on purpose in NumbersRecord.readItem<p>");
-			//throw new MyParentException("Test skip after retry -- Fail on purpose in NumbersRecord.readItem()");	
 		}
 		else if(testState == STATE_SKIP) {
 			if (((Properties)stepCtx.getTransientUserData()).getProperty("skip.read.item.invoked") != "true") {
-				Reporter.log("onSkipReadItem not invoked<p>");
+				logger.info("onSkipReadItem not invoked<p>");
 				throw new Exception("onSkipReadItem not invoked");
 			} else {
-				Reporter.log("onSkipReadItem was invoked<p>");
+				logger.info("onSkipReadItem was invoked<p>");
 			}
 			
 			if (((Properties)stepCtx.getTransientUserData()).getProperty("skip.read.item.match") != "true") {
-				Reporter.log("skippable exception does not match<p>");
+				logger.info("skippable exception does not match<p>");
 				throw new Exception("skippable exception does not match");
 			} else {
-				Reporter.log("skippable exception matches<p>");
+				logger.info("skippable exception matches<p>");
 			}
 			testState = STATE_NORMAL;
 		}
@@ -192,7 +188,7 @@ public class RetryReader extends AbstractItemReader {
 			}
 					
 			readerIndex++;
-			Reporter.log("Read [item: " + i + " quantity: " + quantity + "]<p>");
+			logger.info("Read [item: " + i + " quantity: " + quantity + "]<p>");
 			return new NumbersRecord(i, quantity);
 		} catch (SQLException e) {
 			throw e;

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/chunkartifacts/RetryWriter.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/chunkartifacts/RetryWriter.java
@@ -33,16 +33,17 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.sql.DataSource;
 
-import org.testng.Reporter;
-
 import com.ibm.jbatch.tck.artifacts.chunktypes.NumbersRecord;
 import com.ibm.jbatch.tck.artifacts.reusable.MyParentException;
+import java.util.logging.Logger;
 
 
 @javax.inject.Named("retryWriter")
 public class RetryWriter extends AbstractItemWriter {
 	
-
+	private static final String CLASSNAME = RetryWriter.class.getName();
+	private final static Logger logger = Logger.getLogger(CLASSNAME);
+    
 	protected DataSource dataSource = null;
 	
     @Inject
@@ -92,18 +93,18 @@ public class RetryWriter extends AbstractItemWriter {
 			item = ((NumbersRecord)record).getItem();
 			quantity = ((NumbersRecord)record).getQuantity();
 			
-			Reporter.log("Writing item: " + item + "...<br>");
+			logger.info("Writing item: " + item + "...<br>");
 			
 			// Throw an exception when forcedFailCount is reached
 			if (forcedFailCount != 0 && count >= forcedFailCount && (testState == STATE_NORMAL)) {
 					    //forcedFailCount = 0;
 						testState = STATE_RETRY;
-						Reporter.log("Fail on purpose in NumbersRecord.writeItems<p>");
+						logger.info("Fail on purpose in NumbersRecord.writeItems<p>");
 						throw new MyParentException("Fail on purpose in NumbersRecord.writeItems()");	
 			} else if (forcedFailCount != 0 && count > forcedFailCount && (testState == STATE_EXCEPTION)) {
 				testState = STATE_SKIP;
 				forcedFailCount = 0;
-				Reporter.log("Test skip -- Fail on purpose NumbersRecord.writeItems<p>");
+				logger.info("Test skip -- Fail on purpose NumbersRecord.writeItems<p>");
 				throw new MyParentException("Test skip -- Fail on purpose in NumbersRecord.writeItems()");
 			}
 			
@@ -111,33 +112,33 @@ public class RetryWriter extends AbstractItemWriter {
 			{
 				
 				if (((Properties)stepCtx.getTransientUserData()).getProperty("retry.write.exception.invoked") != "true") {
-					Reporter.log("onRetryWriteException not invoked<p>");
+					logger.info("onRetryWriteException not invoked<p>");
 					throw new Exception("onRetryWriteException not invoked");
 				} else {
-					Reporter.log("onRetryWriteException was invoked<p>");
+					logger.info("onRetryWriteException was invoked<p>");
 				}
 				
 				if (((Properties)stepCtx.getTransientUserData()).getProperty("retry.write.exception.match") != "true") {
-					Reporter.log("retryable exception does not match");
+					logger.info("retryable exception does not match");
 					throw new Exception("retryable exception does not match");
 				} else {
-					Reporter.log("retryable exception matches");
+					logger.info("retryable exception matches");
 				}
 				
 				testState = STATE_EXCEPTION;
 			} else if(testState == STATE_SKIP) {
 				if (((Properties)stepCtx.getTransientUserData()).getProperty("skip.write.item.invoked") != "true") {
-					Reporter.log("onSkipWriteItem not invoked<p>");
+					logger.info("onSkipWriteItem not invoked<p>");
 					throw new Exception("onSkipWriteItem not invoked");
 				} else {
-					Reporter.log("onSkipWriteItem was invoked<p>");
+					logger.info("onSkipWriteItem was invoked<p>");
 				}
 				
 				if (((Properties)stepCtx.getTransientUserData()).getProperty("skip.write.item.match") != "true") {
-					Reporter.log("skippable exception does not match<p>");
+					logger.info("skippable exception does not match<p>");
 					throw new Exception("skippable exception does not match");
 				} else {
-					Reporter.log("skippable exception matches<p>");
+					logger.info("skippable exception matches<p>");
 				}
 				testState = STATE_NORMAL;
 			}
@@ -151,7 +152,7 @@ public class RetryWriter extends AbstractItemWriter {
 				statement = connection.prepareStatement(RetryConnectionHelper.UPDATE_NUMBERS);
 				statement.setInt(2, item);
 				statement.setInt(1, quantity);
-				Reporter.log("Write [item: " + item + " quantity: " + quantity + "]<p>");
+				logger.info("Write [item: " + item + " quantity: " + quantity + "]<p>");
 				int rs = statement.executeUpdate();
 				count++;
 				

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/inner/ParallelContextPropagationArtifacts.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/inner/ParallelContextPropagationArtifacts.java
@@ -27,7 +27,7 @@ import javax.batch.runtime.context.JobContext;
 import javax.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ParallelContextPropagationArtifacts {
 
@@ -87,14 +87,14 @@ public static String GOOD_EXIT_STATUS = "VERY GOOD INVOCATION";
 			 * <property name="topLevelJobProperty" value="topLevelJobProperty.value" />
 			 */
 			String propVal = jobCtx.getProperties().getProperty("topLevelJobProperty");
-			assertEquals("Job Property comparison", "topLevelJobProperty.value", propVal);
+			assertEquals("topLevelJobProperty.value", propVal, "Job Property comparison");
 			
 			propVal = stepCtx.getProperties().getProperty("topLevelStepProperty");
-			assertEquals("Step Property comparison", "topLevelStepProperty.value", propVal);
+			assertEquals("topLevelStepProperty.value", propVal, "Step Property comparison");
 			
-			assertEquals("Job name", "partitionCtxPropagation", jobCtx.getJobName());
+			assertEquals("partitionCtxPropagation", jobCtx.getJobName(), "Job name");
 
-			assertEquals("Step name", "step1", stepCtx.getStepName());
+			assertEquals("step1", stepCtx.getStepName(), "Step name");
 
 			return GOOD_EXIT_STATUS;
 		}
@@ -111,7 +111,7 @@ public static String GOOD_EXIT_STATUS = "VERY GOOD INVOCATION";
 		@Override
 		public String collectPartitionData() throws Exception {
 
-			assertEquals("step name", "step1", stepCtx.getStepName());
+			assertEquals("step1", stepCtx.getStepName(), "step name");
 
 			long jobid = jobCtx.getExecutionId();
 			long instanceid = jobCtx.getInstanceId();

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/MyMultipleExceptionsRetryReadListener.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/MyMultipleExceptionsRetryReadListener.java
@@ -25,7 +25,7 @@ import javax.batch.runtime.context.JobContext;
 import javax.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
-import org.testng.Reporter;
+
 
 import com.ibm.jbatch.tck.artifacts.reusable.MyParentException;
 
@@ -47,13 +47,13 @@ public class MyMultipleExceptionsRetryReadListener implements RetryReadListener 
 	
 	@Override
 	public void onRetryReadException(Exception ex) throws Exception {
-        Reporter.log("In onSkipReadItem" + ex + "<p>");
+        logger.info("In onSkipReadItem" + ex + "<p>");
 
         if (ex instanceof MyParentException) {
-        	Reporter.log("SKIPLISTENER: onSkipReadItem, exception is an instance of: MyParentException<p>");
+        	logger.info("SKIPLISTENER: onSkipReadItem, exception is an instance of: MyParentException<p>");
             jobCtx.setExitStatus(GOOD_EXIT_STATUS);
         } else {
-        	Reporter.log("SKIPLISTENER: onSkipReadItem, exception is NOT an instance of: MyParentException<p>");
+        	logger.info("SKIPLISTENER: onSkipReadItem, exception is NOT an instance of: MyParentException<p>");
             jobCtx.setExitStatus(BAD_EXIT_STATUS);
         }
     }

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/MyRetryProcessListener.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/MyRetryProcessListener.java
@@ -24,9 +24,6 @@ import javax.batch.api.chunk.listener.RetryProcessListener;
 import javax.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 
-import org.testng.Reporter;
-
-
 @javax.inject.Named("myRetryProcessListener")
 public class MyRetryProcessListener implements RetryProcessListener {
 	 private final static String sourceClass = MyRetryProcessListener.class.getName();
@@ -37,7 +34,7 @@ public class MyRetryProcessListener implements RetryProcessListener {
 
 	    @Override
 	    public void onRetryProcessException(Object o, Exception e) {
-	    	Reporter.log("In onRetryProcessException()" + e);
+	    	logger.info("In onRetryProcessException()" + e);
 	    	jobCtx.setExitStatus("Retry listener invoked");
 	    }
 }

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/MyRetryReadListener.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/MyRetryReadListener.java
@@ -24,8 +24,6 @@ import javax.batch.api.chunk.listener.RetryReadListener;
 import javax.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 
-import org.testng.Reporter;
-
 @javax.inject.Named("myRetryReadListener")
 public class MyRetryReadListener implements RetryReadListener {
 	 private final static String sourceClass = MyRetryReadListener.class.getName();
@@ -36,7 +34,7 @@ public class MyRetryReadListener implements RetryReadListener {
 
 	    @Override
 	    public void onRetryReadException(Exception e) {
-	    	Reporter.log("In onRetryReadException()" + e);
+	    	logger.info("In onRetryReadException()" + e);
 	    	jobCtx.setExitStatus("Retry listener invoked");
 	    }
 }

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/MyRetryWriteListener.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/MyRetryWriteListener.java
@@ -25,8 +25,6 @@ import javax.batch.api.chunk.listener.RetryWriteListener;
 import javax.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 
-import org.testng.Reporter;
-
 
 @javax.inject.Named("myRetryWriteListener")
 public class MyRetryWriteListener implements RetryWriteListener {
@@ -38,7 +36,7 @@ public class MyRetryWriteListener implements RetryWriteListener {
 
 	    @Override
 	    public void onRetryWriteException(List w, Exception e) {
-	    	Reporter.log("In onRetryWriteException()" + e);
+	    	logger.info("In onRetryWriteException()" + e);
 	    	jobCtx.setExitStatus("Retry listener invoked");
 	    }
 }

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/MySkipProcessListener.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/MySkipProcessListener.java
@@ -25,8 +25,6 @@ import javax.batch.runtime.context.JobContext;
 import javax.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
-import org.testng.Reporter;
-
 import com.ibm.jbatch.tck.artifacts.chunktypes.ReadRecord;
 import com.ibm.jbatch.tck.artifacts.reusable.MyParentException;
 
@@ -47,7 +45,7 @@ public class MySkipProcessListener implements SkipProcessListener {
 
 	@Override
 	public void onSkipProcessItem(Object item, Exception e) {
-		Reporter.log("In onSkipProcessItem()" + e + "<p>");
+		logger.info("In onSkipProcessItem()" + e + "<p>");
 
 		ReadRecord input = (ReadRecord)item;
 
@@ -55,10 +53,10 @@ public class MySkipProcessListener implements SkipProcessListener {
 			logger.finer("In onSkipProcessItem(), item count = " + input.getCount());
 
 			if (e instanceof MyParentException) {
-				Reporter.log("SKIPLISTENER: onSkipProcessItem, exception is an instance of: MyParentException<p>");
+				logger.info("SKIPLISTENER: onSkipProcessItem, exception is an instance of: MyParentException<p>");
 				jobCtx.setExitStatus(GOOD_EXIT_STATUS);
 			} else {
-				Reporter.log("SKIPLISTENER: onSkipProcessItem, exception is NOT an instance of: MyParentException<p>");
+				logger.info("SKIPLISTENER: onSkipProcessItem, exception is NOT an instance of: MyParentException<p>");
 				jobCtx.setExitStatus(BAD_EXIT_STATUS);
 			}
 		}

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/MySkipReadListener.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/MySkipReadListener.java
@@ -25,8 +25,6 @@ import javax.batch.runtime.context.JobContext;
 import javax.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
-import org.testng.Reporter;
-
 import com.ibm.jbatch.tck.artifacts.reusable.MyParentException;
 
 @javax.inject.Named("mySkipReadListener")
@@ -46,13 +44,13 @@ public class MySkipReadListener implements SkipReadListener {
 
     @Override
     public void onSkipReadItem(Exception e) {
-        Reporter.log("In onSkipReadItem" + e + "<p>");
+        logger.info("In onSkipReadItem" + e + "<p>");
 
         if (e instanceof MyParentException) {
-        	Reporter.log("SKIPLISTENER: onSkipReadItem, exception is an instance of: MyParentException<p>");
+        	logger.info("SKIPLISTENER: onSkipReadItem, exception is an instance of: MyParentException<p>");
             jobCtx.setExitStatus(GOOD_EXIT_STATUS);
         } else {
-        	Reporter.log("SKIPLISTENER: onSkipReadItem, exception is NOT an instance of: MyParentException<p>");
+        	logger.info("SKIPLISTENER: onSkipReadItem, exception is NOT an instance of: MyParentException<p>");
             jobCtx.setExitStatus(BAD_EXIT_STATUS);
         }
     }

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/MySkipReaderExceedListener.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/MySkipReaderExceedListener.java
@@ -25,8 +25,6 @@ import javax.batch.runtime.context.JobContext;
 import javax.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
-import org.testng.Reporter;
-
 import com.ibm.jbatch.tck.artifacts.reusable.MyParentException;
 
 @javax.inject.Named("mySkipReaderExceedListener")
@@ -49,17 +47,17 @@ public class MySkipReaderExceedListener implements SkipReadListener {
     
     @Override
     public void onSkipReadItem(Exception e) {
-        Reporter.log("In onSkipReadItem" + e + "<p>");
+        logger.info("In onSkipReadItem" + e + "<p>");
         
         count++;
         
         if (e instanceof MyParentException) {
         	if (count == 1){
-        		Reporter.log("SKIPLISTENER: onSkipReadItem, exception is an instance of: MyParentException and number of skips is equal to 1<p>");
+        		logger.info("SKIPLISTENER: onSkipReadItem, exception is an instance of: MyParentException and number of skips is equal to 1<p>");
         		jobCtx.setExitStatus(GOOD_EXIT_STATUS);
         	}
         	else {
-        		Reporter.log("SKIPLISTENER: onSkipReadItem invoked more than expected and/or wrong exception skipped");
+        		logger.info("SKIPLISTENER: onSkipReadItem invoked more than expected and/or wrong exception skipped");
                 jobCtx.setExitStatus(BAD_EXIT_STATUS_INCORRECT_NUMBER_SKIPS);
         	}
         } 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/MySkipWriteListener.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/MySkipWriteListener.java
@@ -26,8 +26,6 @@ import javax.batch.runtime.context.JobContext;
 import javax.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
-import org.testng.Reporter;
-
 import com.ibm.jbatch.tck.artifacts.chunktypes.ReadRecord;
 import com.ibm.jbatch.tck.artifacts.reusable.MyParentException;
 
@@ -48,7 +46,7 @@ public class MySkipWriteListener implements SkipWriteListener {
 
     @Override
     public void onSkipWriteItem(List items, Exception e) {
-        Reporter.log("In onSkipWriteItem()" + e + "<p>");
+        logger.info("In onSkipWriteItem()" + e + "<p>");
         ReadRecord input = null;
         boolean inputOK = false;
         
@@ -62,10 +60,10 @@ public class MySkipWriteListener implements SkipWriteListener {
         }
 
         if (e instanceof MyParentException && inputOK) {
-        	Reporter.log("SKIPLISTENER: onSkipWriteItem, exception is an instance of: MyParentException<p>");
+        	logger.info("SKIPLISTENER: onSkipWriteItem, exception is an instance of: MyParentException<p>");
             jobCtx.setExitStatus(GOOD_EXIT_STATUS);
         } else {
-        	Reporter.log("SKIPLISTENER: onSkipWriteItem, exception is NOT an instance of: MyParentException<p>");
+        	logger.info("SKIPLISTENER: onSkipWriteItem, exception is NOT an instance of: MyParentException<p>");
             jobCtx.setExitStatus(BAD_EXIT_STATUS);
         }
     }

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/NumbersRetryProcessListener.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/NumbersRetryProcessListener.java
@@ -25,8 +25,6 @@ import javax.batch.api.chunk.listener.RetryProcessListener;
 import javax.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
-import org.testng.Reporter;
-
 import com.ibm.jbatch.tck.artifacts.reusable.MyParentException;
 
 @javax.inject.Named("numbersRetryProcessListener")
@@ -39,7 +37,7 @@ public class NumbersRetryProcessListener implements RetryProcessListener {
 
 	    @Override
 	    public void onRetryProcessException(Object o, Exception e) {
-	    	Reporter.log("In onRetryProcessException()" + e + "<p>");
+	    	logger.info("In onRetryProcessException()" + e + "<p>");
 	    	logger.finer("In onRetryProcessException()" + e);
 	    	((Properties)stepCtx.getTransientUserData()).setProperty("retry.process.exception.invoked", "true");
 	        if (e instanceof MyParentException){

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/NumbersRetryReadListener.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/NumbersRetryReadListener.java
@@ -25,7 +25,7 @@ import javax.batch.api.chunk.listener.RetryReadListener;
 import javax.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
-import org.testng.Reporter;
+
 
 import com.ibm.jbatch.tck.artifacts.reusable.MyParentException;
 
@@ -39,7 +39,7 @@ public class NumbersRetryReadListener implements RetryReadListener {
 
 	    @Override
 	    public void onRetryReadException(Exception e) {
-	    	Reporter.log("In onRetryReadException()" + e);
+	    	logger.info("In onRetryReadException()" + e);
 	    	logger.finer("In onRetryReadException()" + e);
 	    	((Properties)stepCtx.getTransientUserData()).setProperty("retry.read.exception.invoked", "true");
 	        if (e instanceof MyParentException){

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/NumbersRetryWriteListener.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/NumbersRetryWriteListener.java
@@ -26,7 +26,7 @@ import javax.batch.api.chunk.listener.RetryWriteListener;
 import javax.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
-import org.testng.Reporter;
+
 
 import com.ibm.jbatch.tck.artifacts.reusable.MyParentException;
 
@@ -40,7 +40,7 @@ public class NumbersRetryWriteListener implements RetryWriteListener {
 
 	    @Override
 	    public void onRetryWriteException(List w, Exception e) {
-	    	Reporter.log("In onRetryWriteException()" + e);
+	    	logger.info("In onRetryWriteException()" + e);
 	    	logger.finer("In onRetryWriteException()" + e);
 	    	((Properties)stepCtx.getTransientUserData()).setProperty("retry.write.exception.invoked", "true");
 	        if (e instanceof MyParentException){

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/NumbersSkipProcessListener.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/NumbersSkipProcessListener.java
@@ -25,7 +25,7 @@ import javax.batch.api.chunk.listener.SkipProcessListener;
 import javax.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
-import org.testng.Reporter;
+
 
 import com.ibm.jbatch.tck.artifacts.reusable.MyParentException;
 
@@ -40,7 +40,7 @@ public class NumbersSkipProcessListener implements SkipProcessListener {
 
     @Override
     public void onSkipProcessItem(Object o, Exception e) {
-        Reporter.log("In onSkipProcessItem" + e + "<p>");
+        logger.info("In onSkipProcessItem" + e + "<p>");
 
         ((Properties)stepCtx.getTransientUserData()).setProperty("skip.process.item.invoked", "true");
         if (e instanceof MyParentException){

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/NumbersSkipReadListener.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/NumbersSkipReadListener.java
@@ -25,7 +25,7 @@ import javax.batch.api.chunk.listener.SkipReadListener;
 import javax.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
-import org.testng.Reporter;
+
 
 import com.ibm.jbatch.tck.artifacts.reusable.MyParentException;
 
@@ -40,7 +40,7 @@ public class NumbersSkipReadListener implements SkipReadListener {
 
     @Override
     public void onSkipReadItem(Exception e) {
-        Reporter.log("In onSkipReadItem" + e + "<p>");
+        logger.info("In onSkipReadItem" + e + "<p>");
 
         ((Properties)stepCtx.getTransientUserData()).setProperty("skip.read.item.invoked", "true");
         if (e instanceof MyParentException){

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/NumbersSkipWriteListener.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/NumbersSkipWriteListener.java
@@ -26,7 +26,7 @@ import javax.batch.api.chunk.listener.SkipWriteListener;
 import javax.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
-import org.testng.Reporter;
+
 
 import com.ibm.jbatch.tck.artifacts.reusable.MyParentException;
 
@@ -41,7 +41,7 @@ public class NumbersSkipWriteListener implements SkipWriteListener {
 
     @Override
     public void onSkipWriteItem(List w, Exception e) {
-        Reporter.log("In onSkipWriteItem" + e + "<p>");
+        logger.info("In onSkipWriteItem" + e + "<p>");
 
         ((Properties)stepCtx.getTransientUserData()).setProperty("skip.write.item.invoked", "true");
         if (e instanceof MyParentException){

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/VerifySkipWriteListener.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/artifacts/specialized/VerifySkipWriteListener.java
@@ -27,7 +27,7 @@ import javax.batch.runtime.context.JobContext;
 import javax.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
-import org.testng.Reporter;
+
 
 import com.ibm.jbatch.tck.artifacts.chunktypes.ReadRecord;
 import com.ibm.jbatch.tck.artifacts.reusable.MyParentException;
@@ -60,7 +60,7 @@ public class VerifySkipWriteListener implements SkipWriteListener {
 
     @Override
     public void onSkipWriteItem(List items, Exception e) throws Exception {
-        Reporter.log("In onSkipWriteItem()" + e + "<p>");
+        logger.info("In onSkipWriteItem()" + e + "<p>");
         ReadRecord input  = null;
         boolean inputOK   = true;
         int numberOfNonNullItemsFound = 0; //count the number of non-null items found in the list
@@ -90,10 +90,10 @@ public class VerifySkipWriteListener implements SkipWriteListener {
         }
         
         if (e instanceof MyParentException && inputOK) {
-        	Reporter.log("VERIFYSKIPLISTENER: onSkipWriteItem, exception is an instance of: MyParentException<p>");
+        	logger.info("VERIFYSKIPLISTENER: onSkipWriteItem, exception is an instance of: MyParentException<p>");
             jobCtx.setExitStatus(GOOD_EXIT_STATUS);
         } else {
-        	Reporter.log("VERIFYSKIPLISTENER: onSkipWriteItem, exception is NOT an instance of: MyParentException<p>");
+        	logger.info("VERIFYSKIPLISTENER: onSkipWriteItem, exception is NOT an instance of: MyParentException<p>");
             jobCtx.setExitStatus(BAD_EXIT_STATUS);
             throw new Exception(); //fail immediately, don't wait for assertion. next iteration of this class could overwrite status.
         }

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/ee/TransactionTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/ee/TransactionTests.java
@@ -32,44 +32,26 @@ import javax.batch.runtime.StepExecution;
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
 import com.ibm.jbatch.tck.utils.TCKJobExecutionWrapper;
 
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.testng.Reporter;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.*;
 
-// Since we don't want to run these in SE, and are only really running TestNG in EE, we
-// can safely do a JUnit @Ignore without missing anything.
-@Ignore
+@Tag("EE")
 public class TransactionTests {
 
 	private final static Logger logger = Logger.getLogger(TransactionTests.class.getName());
 
-	private static JobOperatorBridge jobOp;
+	private JobOperatorBridge jobOp;
 
-	public static void setup(String[] args, Properties props) throws Exception {
-		String METHOD = "setup";
-
-		try {
-			jobOp = new JobOperatorBridge();
-		} catch (Exception e) {
-			handleException(METHOD, e);
-		}
-	}
-
-	@BeforeMethod
-	@BeforeClass
-	public static void setUp() throws Exception {
+	@BeforeEach
+	public void setUp() throws Exception {
 		jobOp = new JobOperatorBridge();
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void cleanup() throws Exception {
 	}
 
 	private void begin(String str) {
-		Reporter.log("Begin test method: " + str + "<p>");
+		logger.info("Begin test method: " + str + "<p>");
 	}
 
 
@@ -85,7 +67,7 @@ public class TransactionTests {
 	 *
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testTranRollbackRetryReadSkipRead() throws Exception {
 		String METHOD = "testTranRollbackRetryReadSkipRead";
 		begin(METHOD);
@@ -111,9 +93,9 @@ public class TransactionTests {
 			jobParams.put("rollback", rollback.toString());
 			jobParams.put("auto.commit", autoCommit.toString());
 
-			Reporter.log("Locate job XML file: job_chunk_retryskip_rollback.xml<p>");
+			logger.info("Locate job XML file: job_chunk_retryskip_rollback.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_chunk_retryskip_rollback",jobParams);
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 		} catch (Exception e) {
@@ -133,7 +115,7 @@ public class TransactionTests {
 	 *
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testTranRollbackRetryProcessSkipProcess() throws Exception {
 		String METHOD = "testTranRollbackRetryProcessSkipProcess";
 		begin(METHOD);
@@ -159,9 +141,9 @@ public class TransactionTests {
 			jobParams.put("rollback", rollback.toString());
 			jobParams.put("auto.commit", autoCommit.toString());
 
-			Reporter.log("Locate job XML file: job_chunk_retryskip_rollback.xml<p>");
+			logger.info("Locate job XML file: job_chunk_retryskip_rollback.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_chunk_retryskip_rollback",jobParams);
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 		} catch (Exception e) {
@@ -181,7 +163,7 @@ public class TransactionTests {
 	 *
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testTranRollbackRetryWriteSkipWrite() throws Exception {
 		String METHOD = "testTranRollbackRetryWriteSkipWrite";
 		begin(METHOD);
@@ -207,9 +189,9 @@ public class TransactionTests {
 			jobParams.put("rollback", rollback.toString());
 			jobParams.put("auto.commit", autoCommit.toString());
 
-			Reporter.log("Locate job XML file: job_chunk_retryskip_rollback.xml<p>");
+			logger.info("Locate job XML file: job_chunk_retryskip_rollback.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_chunk_retryskip_rollback",jobParams);
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 		} catch (Exception e) {
@@ -223,7 +205,7 @@ public class TransactionTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test  
+  
 	public void testGlobalTranNoExceptions() throws Exception {
 		String METHOD = "testGlobalTranNoExceptions";
 		begin(METHOD);
@@ -242,13 +224,13 @@ public class TransactionTests {
 			Integer expectedCompletedOrders = this.calculateExpectedCompleteOrders(initInventory, forcedFailCount, itemCount);
 
 			Properties jobParams = new Properties();
-			Reporter.log("Create job parameters for execution #1:<p>");
-			Reporter.log("javax.transaction.global.timeout=300<p>");
-			Reporter.log("commit.interval="+itemCount.toString()+"<p>");
-			Reporter.log("init.inventory.quantity="+initInventory.toString()+"<p>");
-			Reporter.log("forced.fail.count="+forcedFailCount.toString()+"<p>");
-			Reporter.log("dummy.delay.seconds="+dummyDelay.toString()+"<p>");
-			Reporter.log("expected.inventory="+expectedInventory.toString()+"<p>");
+			logger.info("Create job parameters for execution #1:<p>");
+			logger.info("javax.transaction.global.timeout=300<p>");
+			logger.info("commit.interval="+itemCount.toString()+"<p>");
+			logger.info("init.inventory.quantity="+initInventory.toString()+"<p>");
+			logger.info("forced.fail.count="+forcedFailCount.toString()+"<p>");
+			logger.info("dummy.delay.seconds="+dummyDelay.toString()+"<p>");
+			logger.info("expected.inventory="+expectedInventory.toString()+"<p>");
 			jobParams.put("javax.transaction.global.timeout", "300");
 			jobParams.put("commit.interval", itemCount.toString());
 			jobParams.put("init.inventory.quantity", initInventory.toString());
@@ -257,11 +239,11 @@ public class TransactionTests {
 			jobParams.put("expected.inventory", expectedInventory.toString());
 
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_chunk_globaltran",jobParams);
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
-			Reporter.log("execution #1 JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
 			assertObjEquals("Inventory=" +expectedInventory + " InitialCheckpoint=" + null +" OrderCount="+ expectedCompletedOrders , jobExec.getExitStatus());
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 		} catch (Exception e) {
@@ -277,7 +259,7 @@ public class TransactionTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testGlobalTranForcedExceptionWithRollback() throws Exception {
 		String METHOD = "testGlobalTranForcedExceptionWithRollback";
 		begin(METHOD);
@@ -296,13 +278,13 @@ public class TransactionTests {
 
 			Properties jobParams = new Properties();
 
-			Reporter.log("Create job parameters for execution #1:<p>");
-			Reporter.log("javax.transaction.global.timeout=300<p>");
-			Reporter.log("commit.interval="+itemCount.toString()+"<p>");
-			Reporter.log("init.inventory.quantity="+initInventory.toString()+"<p>");
-			Reporter.log("forced.fail.count="+forcedFailCount.toString()+"<p>");
-			Reporter.log("dummy.delay.seconds="+dummyDelay.toString()+"<p>");
-			Reporter.log("expected.inventory="+expectedInventory.toString()+"<p>");
+			logger.info("Create job parameters for execution #1:<p>");
+			logger.info("javax.transaction.global.timeout=300<p>");
+			logger.info("commit.interval="+itemCount.toString()+"<p>");
+			logger.info("init.inventory.quantity="+initInventory.toString()+"<p>");
+			logger.info("forced.fail.count="+forcedFailCount.toString()+"<p>");
+			logger.info("dummy.delay.seconds="+dummyDelay.toString()+"<p>");
+			logger.info("expected.inventory="+expectedInventory.toString()+"<p>");
 			jobParams.put("javax.transaction.global.timeout", "300");
 			jobParams.put("commit.interval", itemCount.toString());
 			jobParams.put("init.inventory.quantity", initInventory.toString());
@@ -310,11 +292,11 @@ public class TransactionTests {
 			jobParams.put("dummy.delay.seconds", dummyDelay.toString());
 			jobParams.put("expected.inventory", expectedInventory.toString());
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_chunk_globaltran",jobParams);
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
-			Reporter.log("execution #1 JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
 			assertObjEquals("Inventory=" +expectedInventory + " InitialCheckpoint=" + null +" OrderCount="+ expectedCompletedOrders , jobExec.getExitStatus());
 			assertObjEquals(BatchStatus.FAILED, jobExec.getBatchStatus());
 		} catch (Exception e) {
@@ -329,7 +311,7 @@ public class TransactionTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test  
+  
 	public void testGlobalTranForcedExceptionCheckpointRestart() throws Exception {
 		String METHOD = "testGlobalTranForcedExceptionCheckpointRestart";
 		begin(METHOD);
@@ -348,13 +330,13 @@ public class TransactionTests {
 
 			Properties jobParams = new Properties();
 
-			Reporter.log("Create job parameters for execution #1:<p>");
-			Reporter.log("javax.transaction.global.timeout=300<p>");
-			Reporter.log("commit.interval="+itemCount.toString()+"<p>");
-			Reporter.log("init.inventory.quantity="+initInventory.toString()+"<p>");
-			Reporter.log("forced.fail.count="+forcedFailCount.toString()+"<p>");
-			Reporter.log("dummy.delay.seconds="+dummyDelay.toString()+"<p>");
-			Reporter.log("expected.inventory="+expectedInventory.toString()+"<p>");
+			logger.info("Create job parameters for execution #1:<p>");
+			logger.info("javax.transaction.global.timeout=300<p>");
+			logger.info("commit.interval="+itemCount.toString()+"<p>");
+			logger.info("init.inventory.quantity="+initInventory.toString()+"<p>");
+			logger.info("forced.fail.count="+forcedFailCount.toString()+"<p>");
+			logger.info("dummy.delay.seconds="+dummyDelay.toString()+"<p>");
+			logger.info("expected.inventory="+expectedInventory.toString()+"<p>");
 			jobParams.put("javax.transaction.global.timeout", "300");
 			jobParams.put("commit.interval", itemCount.toString());
 			jobParams.put("init.inventory.quantity", initInventory.toString());
@@ -363,12 +345,12 @@ public class TransactionTests {
 			jobParams.put("expected.inventory", expectedInventory.toString());
 
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			TCKJobExecutionWrapper jobExec = jobOp.startJobAndWaitForResult("job_chunk_globaltran",jobParams);
 			long jobInstanceId = jobExec.getInstanceId();
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
-			Reporter.log("execution #1 JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
 			assertObjEquals(BatchStatus.FAILED, jobExec.getBatchStatus());
 			assertObjEquals("Inventory=" +expectedInventory + " InitialCheckpoint=" + null +" OrderCount="+ expectedCompletedOrders , jobExec.getExitStatus());
 
@@ -378,11 +360,11 @@ public class TransactionTests {
 			expectedInventory = TransactionTests.calculateGlobalTranExpectedInventory(expectedInventory, forcedFailCount, itemCount);
 			Integer expectedCompletedOrders2 = TransactionTests.calculateExpectedCompleteOrders(initInventory, forcedFailCount, itemCount);
 
-			Reporter.log("Invoke restartJobAndWaitForResult with id: " + jobInstanceId + "<p>");
+			logger.info("Invoke restartJobAndWaitForResult with id: " + jobInstanceId + "<p>");
 			JobExecution restartedJobExec = jobOp.restartJobAndWaitForResult(jobExec.getExecutionId(), jobParams);
 
-			Reporter.log("restarted job JobExecution getBatchStatus()="+restartedJobExec.getBatchStatus()+"<p>");
-			Reporter.log("restarted job JobExecution getExitStatus()="+restartedJobExec.getExitStatus()+"<p>");
+			logger.info("restarted job JobExecution getBatchStatus()="+restartedJobExec.getBatchStatus()+"<p>");
+			logger.info("restarted job JobExecution getExitStatus()="+restartedJobExec.getExitStatus()+"<p>");
 			assertObjEquals("Inventory=" +expectedInventory + " InitialCheckpoint=" + expectedCompletedOrders+" OrderCount="+ expectedCompletedOrders2, restartedJobExec.getExitStatus());
 			assertObjEquals(BatchStatus.COMPLETED, restartedJobExec.getBatchStatus());
 		} catch (Exception e) {
@@ -399,7 +381,7 @@ public class TransactionTests {
 	 *                 normally.
 	 */    
 	@Test
-	@org.junit.Test
+
 	public void testGlobalTranNoDelayLongTimeout() throws Exception {
 		String METHOD = "testGlobalTranNoDelayLongTimeout";
 		begin(METHOD);
@@ -421,23 +403,23 @@ public class TransactionTests {
 
 			Properties jobParams = new Properties();
 
-			Reporter.log("Create job parameters for execution #1:<p>");
-			Reporter.log("commit.interval="+itemCount.toString()+"<p>");
-			Reporter.log("init.inventory.quantity="+initInventory.toString()+"<p>");
-			Reporter.log("forced.fail.count="+forcedFailCount.toString()+"<p>");
-			Reporter.log("dummy.delay.seconds="+dummyDelay.toString()+"<p>");
-			Reporter.log("expected.inventory="+expectedInventory.toString()+"<p>");
+			logger.info("Create job parameters for execution #1:<p>");
+			logger.info("commit.interval="+itemCount.toString()+"<p>");
+			logger.info("init.inventory.quantity="+initInventory.toString()+"<p>");
+			logger.info("forced.fail.count="+forcedFailCount.toString()+"<p>");
+			logger.info("dummy.delay.seconds="+dummyDelay.toString()+"<p>");
+			logger.info("expected.inventory="+expectedInventory.toString()+"<p>");
 			jobParams.put("commit.interval", itemCount.toString());
 			jobParams.put("init.inventory.quantity", initInventory.toString());
 			jobParams.put("forced.fail.count", forcedFailCount.toString());
 			jobParams.put("dummy.delay.seconds", dummyDelay.toString());
 			jobParams.put("expected.inventory", expectedInventory.toString());
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			TCKJobExecutionWrapper jobExec = jobOp.startJobAndWaitForResult("job_chunk_globaltran_default",jobParams);
 			
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
-			Reporter.log("execution #1 JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
 			assertObjEquals("Inventory=" +expectedInventory + " InitialCheckpoint=" + null +" OrderCount="+ expectedCompletedOrders , jobExec.getExitStatus());
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 
@@ -469,7 +451,7 @@ public class TransactionTests {
 	 *                 to hint at it and possibly catch an implementation doing something completely off-base.
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testGlobalTranLongDelayMixOfLongTimeoutStepsAndShortTimeoutSteps() throws Exception {
 		String METHOD = "testGlobalTranLongDelayMixOfLongTimeoutStepsAndShortTimeoutSteps";
 		begin(METHOD);
@@ -485,21 +467,21 @@ public class TransactionTests {
 
 			Properties jobParams = new Properties();
 
-			Reporter.log("Create job parameters for execution #1:<p>");
-			Reporter.log("commit.interval="+itemCount.toString()+"<p>");
-			Reporter.log("init.inventory.quantity="+initInventory.toString()+"<p>");
-			Reporter.log("forced.fail.count="+forcedFailCount.toString()+"<p>");
-			Reporter.log("dummy.delay.seconds="+dummyDelay.toString()+"<p>");
+			logger.info("Create job parameters for execution #1:<p>");
+			logger.info("commit.interval="+itemCount.toString()+"<p>");
+			logger.info("init.inventory.quantity="+initInventory.toString()+"<p>");
+			logger.info("forced.fail.count="+forcedFailCount.toString()+"<p>");
+			logger.info("dummy.delay.seconds="+dummyDelay.toString()+"<p>");
 			jobParams.put("commit.interval", itemCount.toString());
 			jobParams.put("init.inventory.quantity", initInventory.toString());
 			jobParams.put("forced.fail.count", forcedFailCount.toString());
 			jobParams.put("dummy.delay.seconds", dummyDelay.toString());
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			TCKJobExecutionWrapper jobExec = jobOp.startJobAndWaitForResult("job_chunk_globaltran_multiple_steps",jobParams);
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
-			Reporter.log("execution #1 JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 			// With test refactoring all orders will be processed, and all inventory depleted.
 			assertObjEquals("Inventory=0 InitialCheckpoint=null OrderCount="+ initInventory, jobExec.getExitStatus());
@@ -542,7 +524,7 @@ public class TransactionTests {
 	 *                 The long timeouts are longer than the "long" delay, so steps 2, 3 complete successfully.  
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testGlobalTranLongDelayMixOfLongTimeoutStepsAndShortTimeoutStepsCustomCheckpointAlgorithm() throws Exception {
 		String METHOD = "testGlobalTranLongDelayMixOfLongTimeoutStepsAndShortTimeoutStepsCustomCheckpointAlgorithm";
 		begin(METHOD);
@@ -558,21 +540,21 @@ public class TransactionTests {
 
 			Properties jobParams = new Properties();
 
-			Reporter.log("Create job parameters for execution #1:<p>");
-			Reporter.log("commit.interval="+itemCount.toString()+"<p>");
-			Reporter.log("init.inventory.quantity="+initInventory.toString()+"<p>");
-			Reporter.log("forced.fail.count="+forcedFailCount.toString()+"<p>");
-			Reporter.log("dummy.delay.seconds="+dummyDelay.toString()+"<p>");
+			logger.info("Create job parameters for execution #1:<p>");
+			logger.info("commit.interval="+itemCount.toString()+"<p>");
+			logger.info("init.inventory.quantity="+initInventory.toString()+"<p>");
+			logger.info("forced.fail.count="+forcedFailCount.toString()+"<p>");
+			logger.info("dummy.delay.seconds="+dummyDelay.toString()+"<p>");
 			jobParams.put("commit.interval", itemCount.toString());
 			jobParams.put("init.inventory.quantity", initInventory.toString());
 			jobParams.put("forced.fail.count", forcedFailCount.toString());
 			jobParams.put("dummy.delay.seconds", dummyDelay.toString());
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			TCKJobExecutionWrapper jobExec = jobOp.startJobAndWaitForResult("job_chunk_globaltran_multiple_steps-customCA",jobParams);
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
-			Reporter.log("execution #1 JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 			assertObjEquals("Inventory=0 InitialCheckpoint=null OrderCount="+ initInventory, jobExec.getExitStatus());
 			
@@ -630,8 +612,8 @@ public class TransactionTests {
 	}
 
 	private static void handleException(String methodName, Exception e) throws Exception {
-		Reporter.log("Caught exception: " + e.getMessage()+"<p>");
-		Reporter.log(methodName + " failed<p>");
+		logger.info("Caught exception: " + e.getMessage()+"<p>");
+		logger.info(methodName + " failed<p>");
 		throw e;
 	}
 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/BatchletRestartStateMachineTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/BatchletRestartStateMachineTests.java
@@ -24,32 +24,18 @@ import java.util.Properties;
 
 import javax.batch.runtime.BatchStatus;
 
-import org.junit.BeforeClass;
-import org.testng.Reporter;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
 import com.ibm.jbatch.tck.utils.TCKJobExecutionWrapper;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.*;
 
 public class BatchletRestartStateMachineTests {
 
-	private static JobOperatorBridge jobOp = null;
+	private static final Logger logger = Logger.getLogger(BatchletRestartStateMachineTests.class.getName());
+	private JobOperatorBridge jobOp = null;
 
-	public static void setup(String[] args, Properties props) throws Exception {
-
-		String METHOD = "setup";
-
-		try {
-			jobOp = new JobOperatorBridge();
-		} catch (Exception e) {
-			handleException(METHOD, e);
-		}
-	}
-
-	@BeforeMethod
-	@BeforeClass
-	public static void setUp() throws Exception {
+	@BeforeEach
+	public void setUp() throws Exception {
 		jobOp = new JobOperatorBridge();
 	}
 
@@ -109,7 +95,7 @@ public class BatchletRestartStateMachineTests {
 	 * in the wrong step in the wrong execution (e.g. in execution.number N we shouldn't be in step S).
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testTransitionElementOnAttrValuesWithRestartJobParamOverrides() throws Exception {
 
 		String METHOD = "testTransitionElementOnAttrValuesWithRestartJobParamOverrides";
@@ -123,61 +109,61 @@ public class BatchletRestartStateMachineTests {
 
 			// Create new block to facilitate copy-pasting without inadvertent errors
 			{
-				Reporter.log("Create job parameters for execution #1:<p>");
+				logger.info("Create job parameters for execution #1:<p>");
 				Properties jobParams = new Properties();
-				Reporter.log("execution.number=1<p>");
+				logger.info("execution.number=1<p>");
 				jobParams.setProperty("execution.number", "1");
 				jobParams.setProperty("step1.stop", "ES.STEP1");
 				jobParams.setProperty("step1.next", "ES.XXX");
 				jobParams.setProperty("step2.fail", "ES.STEP2");
 				jobParams.setProperty("step2.next", "ES.XXX");
 
-				Reporter.log("Invoke startJobAndWaitForResult");
+				logger.info("Invoke startJobAndWaitForResult");
 				execution1 = jobOp.startJobAndWaitForResult("overrideOnAttributeValuesUponRestartBatchlet", jobParams);
 
-				Reporter.log("execution #1 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
-				Reporter.log("execution #1 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
+				logger.info("execution #1 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
+				logger.info("execution #1 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
 				assertWithMessage("Testing execution #1", BatchStatus.STOPPED, execution1.getBatchStatus());
 				assertWithMessage("Testing execution #1", "STOPPED", execution1.getExitStatus());
 			}
 
 			{
-				Reporter.log("Create job parameters for execution #2:<p>");
+				logger.info("Create job parameters for execution #2:<p>");
 				Properties restartJobParameters = new Properties();
-				Reporter.log("execution.number=2<p>");
-				Reporter.log("step1.stop=ES.STOP<p>");
-				Reporter.log("step1.next=ES.STEP1<p>");
+				logger.info("execution.number=2<p>");
+				logger.info("step1.stop=ES.STOP<p>");
+				logger.info("step1.next=ES.STEP1<p>");
 				restartJobParameters.setProperty("execution.number", "2");
 				restartJobParameters.setProperty("step1.stop", "ES.STOP");
 				restartJobParameters.setProperty("step1.next", "ES.STEP1");
 				restartJobParameters.setProperty("step2.fail", "ES.STEP2");
 				restartJobParameters.setProperty("step2.next", "ES.STEP2");
-				Reporter.log("Invoke restartJobAndWaitForResult with executionId: " + execution1.getExecutionId() + "<p>");
+				logger.info("Invoke restartJobAndWaitForResult with executionId: " + execution1.getExecutionId() + "<p>");
 				execution2 = jobOp.restartJobAndWaitForResult(execution1.getExecutionId(),restartJobParameters);				
-				Reporter.log("execution #2 JobExecution getBatchStatus()="+execution2.getBatchStatus()+"<p>");
-				Reporter.log("execution #2 JobExecution getExitStatus()="+execution2.getExitStatus()+"<p>");
+				logger.info("execution #2 JobExecution getBatchStatus()="+execution2.getBatchStatus()+"<p>");
+				logger.info("execution #2 JobExecution getExitStatus()="+execution2.getExitStatus()+"<p>");
 				assertWithMessage("Testing execution #2", BatchStatus.FAILED, execution2.getBatchStatus());
 				// See JSL snippet above for where "SUCCESS" comes from
 				assertWithMessage("Testing execution #2", EXECUTION2_EXPECTED_EXIT_STATUS_FROM_JSL_ATTRIBUTE, execution2.getExitStatus());				
 			}
 
 			{
-				Reporter.log("Create job parameters for execution #3:<p>");
+				logger.info("Create job parameters for execution #3:<p>");
 				Properties restartJobParameters = new Properties();
-				Reporter.log("execution.number=3<p>");
-				Reporter.log("step1.stop=ES.STOP<p>");
-				Reporter.log("step1.next=ES.STEP1<p>");
-				Reporter.log("step2.fail=ES.FAIL<p>");
-				Reporter.log("step2.next=ES.STEP2<p>");
+				logger.info("execution.number=3<p>");
+				logger.info("step1.stop=ES.STOP<p>");
+				logger.info("step1.next=ES.STEP1<p>");
+				logger.info("step2.fail=ES.FAIL<p>");
+				logger.info("step2.next=ES.STEP2<p>");
 				restartJobParameters.setProperty("execution.number", "3");
 				restartJobParameters.setProperty("step1.stop", "ES.STOP");
 				restartJobParameters.setProperty("step1.next", "ES.STEP1");
 				restartJobParameters.setProperty("step2.fail", "ES.FAIL");
 				restartJobParameters.setProperty("step2.next", "ES.STEP2");
-				Reporter.log("Invoke restartJobAndWaitForResult with executionId: " + execution2.getExecutionId() + "<p>");
+				logger.info("Invoke restartJobAndWaitForResult with executionId: " + execution2.getExecutionId() + "<p>");
 				execution3 = jobOp.restartJobAndWaitForResult(execution2.getExecutionId(),restartJobParameters);
-				Reporter.log("execution #3 JobExecution getBatchStatus()="+execution3.getBatchStatus()+"<p>");
-				Reporter.log("execution #3 JobExecution getExitStatus()="+execution3.getExitStatus()+"<p>");				
+				logger.info("execution #3 JobExecution getBatchStatus()="+execution3.getBatchStatus()+"<p>");
+				logger.info("execution #3 JobExecution getExitStatus()="+execution3.getExitStatus()+"<p>");				
 				assertWithMessage("Testing execution #3", BatchStatus.COMPLETED, execution3.getBatchStatus());
 				assertWithMessage("Testing execution #3", "COMPLETED", execution3.getExitStatus());  
 			}
@@ -235,7 +221,7 @@ public class BatchletRestartStateMachineTests {
 	 * in the wrong step in the wrong execution (e.g. in execution.number N we shouldn't be in step S).
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testAllowStartIfCompleteRestartExecution() throws Exception {
 
 		String METHOD = "testAllowStartIfCompleteRestartExecution";
@@ -249,16 +235,16 @@ public class BatchletRestartStateMachineTests {
 				Properties jobParameters = new Properties();
 				jobParameters.put("execution.number", execString);
 				if (i == 1) {
-					Reporter.log("Invoking startJobAndWaitForResult for Execution #1<p>");
+					logger.info("Invoking startJobAndWaitForResult for Execution #1<p>");
 					exec = jobOp.startJobAndWaitForResult("batchletRestartStateMachine", jobParameters);
 				} else {
-					Reporter.log("Invoke restartJobAndWaitForResult<p>");
+					logger.info("Invoke restartJobAndWaitForResult<p>");
 					exec = jobOp.restartJobAndWaitForResult(lastExecutionId, jobParameters);
 				}
 				lastExecutionId = exec.getExecutionId();
 
-				Reporter.log("Execution #" + i + " JobExecution getBatchStatus()="+exec.getBatchStatus()+"<p>");
-				Reporter.log("Execution #" + i + " JobExecution getExitStatus()="+exec.getExitStatus()+"<p>");
+				logger.info("Execution #" + i + " JobExecution getBatchStatus()="+exec.getBatchStatus()+"<p>");
+				logger.info("Execution #" + i + " JobExecution getExitStatus()="+exec.getExitStatus()+"<p>");
 				if (i == 6) {
 					assertWithMessage("Testing execution #" + i, BatchStatus.COMPLETED, exec.getBatchStatus());
 				} else {
@@ -273,8 +259,8 @@ public class BatchletRestartStateMachineTests {
 	}
 	
 	private static void handleException(String methodName, Exception e) throws Exception {
-		Reporter.log("Caught exception: " + e.getMessage()+"<p>");
-		Reporter.log(methodName + " failed<p>");
+		logger.info("Caught exception: " + e.getMessage()+"<p>");
+		logger.info(methodName + " failed<p>");
 		throw e;
 	}
 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ChunkTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ChunkTests.java
@@ -39,30 +39,17 @@ import com.ibm.jbatch.tck.artifacts.specialized.MySkipReadListener;
 import com.ibm.jbatch.tck.artifacts.specialized.MySkipWriteListener;
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
 import com.ibm.jbatch.tck.utils.TCKJobExecutionWrapper;
+import java.util.logging.Logger;
 
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.testng.Reporter;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.*;
 
 public class ChunkTests {
 
-    private static JobOperatorBridge jobOp = null;
+    private static final Logger logger = Logger.getLogger(ChunkTests.class.getName());
+    private JobOperatorBridge jobOp = null;
 
-    public static void setup(String[] args, Properties props) throws Exception {
-        String METHOD = "setup";
-
-        try {
-            jobOp = new JobOperatorBridge();
-        } catch (Exception e) {
-            handleException(METHOD, e);
-        }
-    }
-
-    @BeforeMethod
-    @BeforeClass
-    public static void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() throws Exception {
         jobOp = new JobOperatorBridge();
     }
 
@@ -85,27 +72,27 @@ public class ChunkTests {
      *                 job completes successfully. 
      */
     @Test
-    @org.junit.Test
+
     public void testChunkNoProcessorDefined() throws Exception {
         String METHOD = "testChunkDefaultItemCount";
 
         try {
-            Reporter.log("Create job parameters for execution #1:<p>");
+            logger.info("Create job parameters for execution #1:<p>");
             Properties jobParams = new Properties();
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("readrecord.fail=40<p>");
-            Reporter.log("app.arraysize=30<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("readrecord.fail=40<p>");
+            logger.info("app.arraysize=30<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("app.checkpoint.position" , "0");
             jobParams.put("readrecord.fail", "40");
             jobParams.put("app.arraysize", "30");
 
-            Reporter.log("Locate job XML file: chunkNoProcessorDefined.xml<p>");
+            logger.info("Locate job XML file: chunkNoProcessorDefined.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             JobExecution execution1 = jobOp.startJobAndWaitForResult("chunkNoProcessorDefined", jobParams);
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.COMPLETED, execution1.getBatchStatus());
             assertWithMessage("Testing execution #1", "buffer size = 10", execution1.getExitStatus());
         } catch (Exception e) {
@@ -128,18 +115,18 @@ public class ChunkTests {
      *                 job completes successfully. 
      */
     @Test
-    @org.junit.Test
+
     public void testChunkNullCheckpointInfo() throws Exception {
         String METHOD = "testChunkDefaultItemCount";
 
         try {
 
-            Reporter.log("Locate job XML file: nullChkPtInfo.xml<p>");
+            logger.info("Locate job XML file: nullChkPtInfo.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             JobExecution execution1 = jobOp.startJobAndWaitForResult("nullChkPtInfo", null);
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.COMPLETED, execution1.getBatchStatus());
             assertWithMessage("Testing execution #1", "checkpointInfo is null in reader.open...checkpointInfo is null in writer.open", execution1.getExitStatus());
         } catch (Exception e) {
@@ -164,18 +151,18 @@ public class ChunkTests {
     *                 the before/after lifecycle of each listener is contained in the  exit status.
     */
    @Test
-   @org.junit.Test
+
    public void testChunkArtifactInstanceUniqueness() throws Exception {
        String METHOD = "testChunkDefaultItemCount";
 
        try {
 
-           Reporter.log("Locate job XML file: uniqueInstanceTest.xml<p>");
+           logger.info("Locate job XML file: uniqueInstanceTest.xml<p>");
 
-           Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+           logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
            JobExecution execution1 = jobOp.startJobAndWaitForResult("uniqueInstanceTest", null);
-           Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-           Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+           logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+           logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
            assertWithMessage("Testing execution #1", BatchStatus.COMPLETED, execution1.getBatchStatus());
            assertWithMessage("Testing execution #1", "nullChunkListenerChunkListenerStepListenerStepListenerJobListenerJobListener", execution1.getExitStatus());
        } catch (Exception e) {
@@ -200,30 +187,30 @@ public class ChunkTests {
      * 		during the read-write-process batch loop
      */
     @Test
-    @org.junit.Test
+
     public void testChunkOnErrorListener() throws Exception {
     	
     	String METHOD = "testChunkOnErrorListener";
     	
     	try {
-    		Reporter.log("Create job parameters for execution #1:<p>");
+    		logger.info("Create job parameters for execution #1:<p>");
     		Properties jobParams = new Properties();
     		
-    		Reporter.log("execution.number=1<p>");
-            Reporter.log("readrecord.fail=5<p>");
-            Reporter.log("app.arraysize=30<p>");
+    		logger.info("execution.number=1<p>");
+            logger.info("readrecord.fail=5<p>");
+            logger.info("app.arraysize=30<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("readrecord.fail", "5");
             jobParams.put("app.writepoints", "0,10");
             jobParams.put("app.arraysize", "30");
 
-            Reporter.log("Locate job XML file: chunkListenerTest.xml<p>");
+            logger.info("Locate job XML file: chunkListenerTest.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             JobExecution execution1 = jobOp.startJobAndWaitForResult("chunkListenerTest", jobParams);
             
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.FAILED, execution1.getBatchStatus());
             assertWithMessage("Testing execution #1", "Chunk onError invoked", execution1.getExitStatus());
           
@@ -246,18 +233,18 @@ public class ChunkTests {
      *                 test that the processing begins at last recorded check point (item 7) prior to previous failure
      */
     @Test
-    @org.junit.Test
+
     public void testChunkRestartItemCount7() throws Exception {
         String METHOD = "testChunkRestartItemCount7";
 
         try {
 
-            Reporter.log("Create job parameters for execution #1:<p>");
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("readrecord.fail=12<p>");
-            Reporter.log("app.arraysize=30<p>");
-            Reporter.log("app.chunksize=7<p>");
-            Reporter.log("app.commitinterval=10<p>");
+            logger.info("Create job parameters for execution #1:<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("readrecord.fail=12<p>");
+            logger.info("app.arraysize=30<p>");
+            logger.info("app.chunksize=7<p>");
+            logger.info("app.commitinterval=10<p>");
             Properties jobParams = new Properties();
             jobParams.put("execution.number", "1");
             jobParams.put("readrecord.fail", "12");
@@ -266,35 +253,35 @@ public class ChunkTests {
             jobParams.put("app.writepoints", "0,7,14,21,28,30");
             jobParams.put("app.next.writepoints", "7,14,21,28,30");
 
-            Reporter.log("Locate job XML file: chunkStopOnEndOn.xml<p>");
+            logger.info("Locate job XML file: chunkStopOnEndOn.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult<p>");
+            logger.info("Invoke startJobAndWaitForResult<p>");
             TCKJobExecutionWrapper execution1 = jobOp.startJobAndWaitForResult("chunkStopOnEndOn", jobParams);
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.FAILED, execution1.getBatchStatus());
             assertWithMessage("Testing execution #1", "FAILED", execution1.getExitStatus());
 
             long jobInstanceId = execution1.getInstanceId();
             long lastExecutionId = execution1.getExecutionId();
-            Reporter.log("Got Job instance id: " + jobInstanceId + "<p>");
-            Reporter.log("Got Job execution id: " + lastExecutionId + "<p>");
+            logger.info("Got Job instance id: " + jobInstanceId + "<p>");
+            logger.info("Got Job execution id: " + lastExecutionId + "<p>");
             {
-                Reporter.log("Create job parameters for execution #2:<p>");
-                Reporter.log("execution.number=2<p>");
-                Reporter.log("app.arraysize=30<p>");
-                Reporter.log("app.chunksize=7<p>");
-                Reporter.log("app.commitinterval=10<p>");
+                logger.info("Create job parameters for execution #2:<p>");
+                logger.info("execution.number=2<p>");
+                logger.info("app.arraysize=30<p>");
+                logger.info("app.chunksize=7<p>");
+                logger.info("app.commitinterval=10<p>");
                 Properties restartJobParameters = new Properties();
                 restartJobParameters.put("execution.number", "2");
                 restartJobParameters.put("app.arraysize", "30");
                 jobParams.put("app.checkpoint.position" , "7");
-                Reporter.log("Invoke restartJobAndWaitForResult with executionId: " + lastExecutionId + "<p>");
+                logger.info("Invoke restartJobAndWaitForResult with executionId: " + lastExecutionId + "<p>");
                 TCKJobExecutionWrapper exec = jobOp.restartJobAndWaitForResult(lastExecutionId, jobParams);
                 lastExecutionId = exec.getExecutionId();
-                Reporter.log("execution #2 JobExecution getBatchStatus()=" + exec.getBatchStatus() + "<p>");
-                Reporter.log("execution #2 JobExecution getExitStatus()=" + exec.getExitStatus() + "<p>");
-                Reporter.log("execution #2 Job instance id=" + exec.getInstanceId() + "<p>");
+                logger.info("execution #2 JobExecution getBatchStatus()=" + exec.getBatchStatus() + "<p>");
+                logger.info("execution #2 JobExecution getExitStatus()=" + exec.getExitStatus() + "<p>");
+                logger.info("execution #2 Job instance id=" + exec.getInstanceId() + "<p>");
                 assertWithMessage("Testing execution #2", BatchStatus.COMPLETED, exec.getBatchStatus());
                 assertWithMessage("Testing execution #2", "COMPLETED", exec.getExitStatus());
                 assertWithMessage("Testing execution #2", jobInstanceId, exec.getInstanceId());
@@ -318,18 +305,18 @@ public class ChunkTests {
      *                 test that the processing begins at last recorded check point (item 10) prior to previous failure
      */
     @Test
-    @org.junit.Test
+
     public void testChunkRestartItemCount10() throws Exception {
 
         String METHOD = "testChunkRestartItemCount10";
         try {
-            Reporter.log("Create job parameters for execution #1:<p>");
+            logger.info("Create job parameters for execution #1:<p>");
             Properties jobParams = new Properties();
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("readrecord.fail=12<p>");
-            Reporter.log("app.arraysize=30<p>");
-            Reporter.log("app.writepoints=0,5,10,15,20,25,30<p>");
-            Reporter.log("app.next.writepoints=0,5,10,15,20,25,30<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("readrecord.fail=12<p>");
+            logger.info("app.arraysize=30<p>");
+            logger.info("app.writepoints=0,5,10,15,20,25,30<p>");
+            logger.info("app.next.writepoints=0,5,10,15,20,25,30<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("readrecord.fail", "12");
             jobParams.put("app.arraysize", "30");
@@ -337,36 +324,36 @@ public class ChunkTests {
             jobParams.put("app.writepoints", "0,10,20,30");
             jobParams.put("app.next.writepoints", "10,20,30");
 
-            Reporter.log("Locate job XML file: chunkrestartCheckpt10.xml<p>");
+            logger.info("Locate job XML file: chunkrestartCheckpt10.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             TCKJobExecutionWrapper execution1 = jobOp.startJobAndWaitForResult("chunkrestartCheckpt10", jobParams);
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.FAILED, execution1.getBatchStatus());
             assertWithMessage("Testing execution #1", "FAILED", execution1.getExitStatus());
 
             long jobInstanceId = execution1.getInstanceId();
             long lastExecutionId = execution1.getExecutionId();
-            Reporter.log("Got Job instance id: " + jobInstanceId + "<p>");
-            Reporter.log("Got Job execution id: " + lastExecutionId + "<p>");
+            logger.info("Got Job instance id: " + jobInstanceId + "<p>");
+            logger.info("Got Job execution id: " + lastExecutionId + "<p>");
 
             {
-                Reporter.log("Create job parameters for execution #2:<p>");
+                logger.info("Create job parameters for execution #2:<p>");
                 Properties restartJobParameters = new Properties();
-                Reporter.log("execution.number=2<p>");
-                Reporter.log("app.arraysize=30<p>");
-                Reporter.log("app.writepoints=0,5,10,15,20,25,30<p>");
+                logger.info("execution.number=2<p>");
+                logger.info("app.arraysize=30<p>");
+                logger.info("app.writepoints=0,5,10,15,20,25,30<p>");
                 restartJobParameters.put("execution.number", "2");
                 jobParams.put("app.arraysize", "30");
                 jobParams.put("app.checkpoint.position" , "10");
                 jobParams.put("app.writepoints", "0,5,10,15,20,25,30");
-                Reporter.log("Invoke restartJobAndWaitForResult with execution id: " + lastExecutionId + "<p>");
+                logger.info("Invoke restartJobAndWaitForResult with execution id: " + lastExecutionId + "<p>");
                 TCKJobExecutionWrapper exec = jobOp.restartJobAndWaitForResult(lastExecutionId, jobParams);
                 lastExecutionId = exec.getExecutionId();
-                Reporter.log("execution #2 JobExecution getBatchStatus()=" + exec.getBatchStatus() + "<p>");
-                Reporter.log("execution #2 JobExecution getExitStatus()=" + exec.getExitStatus() + "<p>");
-                Reporter.log("execution #2 Job instance id=" + exec.getInstanceId() + "<p>");
+                logger.info("execution #2 JobExecution getBatchStatus()=" + exec.getBatchStatus() + "<p>");
+                logger.info("execution #2 JobExecution getExitStatus()=" + exec.getExitStatus() + "<p>");
+                logger.info("execution #2 Job instance id=" + exec.getInstanceId() + "<p>");
                 assertWithMessage("Testing execution #2", BatchStatus.COMPLETED, exec.getBatchStatus());
                 assertWithMessage("Testing execution #2", "COMPLETED", exec.getExitStatus());
                 assertWithMessage("Testing execution #2", jobInstanceId, exec.getInstanceId());
@@ -390,18 +377,18 @@ public class ChunkTests {
      *                 test that the processing begins at last recorded check point (item 10) prior to previous failure
      */
     @Test
-    @org.junit.Test
+
     public void testChunkRestartChunk5() throws Exception {
 
         String METHOD = "testChunkRestartChunk5";
         try {
-            Reporter.log("Create job parameters for execution #1:<p>");
+            logger.info("Create job parameters for execution #1:<p>");
             Properties jobParams = new Properties();
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("readrecord.fail=12<p>");
-            Reporter.log("app.arraysize=30<p>");
-            Reporter.log("app.writepoints=0,3,6,9,12,15,18,21,24,27,30<p>");
-            Reporter.log("app.next.writepoints=9,12,15,18,21,24,27,30<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("readrecord.fail=12<p>");
+            logger.info("app.arraysize=30<p>");
+            logger.info("app.writepoints=0,3,6,9,12,15,18,21,24,27,30<p>");
+            logger.info("app.next.writepoints=9,12,15,18,21,24,27,30<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("readrecord.fail", "12");
             jobParams.put("app.arraysize", "30");
@@ -409,34 +396,34 @@ public class ChunkTests {
             jobParams.put("app.writepoints", "0,5,10,15,20,25,30");
             jobParams.put("app.next.writepoints", "10,15,20,25,30");
 
-            Reporter.log("Locate job XML file: chunksize5commitinterval3.xml<p>");
+            logger.info("Locate job XML file: chunksize5commitinterval3.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResul for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResul for execution #1<p>");
             TCKJobExecutionWrapper execution1 = jobOp.startJobAndWaitForResult("chunksize5commitinterval3", jobParams);
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.FAILED, execution1.getBatchStatus());
             assertWithMessage("Testing execution #1", "FAILED", execution1.getExitStatus());
 
             long jobInstanceId = execution1.getInstanceId();
             long lastExecutionId = execution1.getExecutionId();
-            Reporter.log("Got Job instance id: " + jobInstanceId + "<p>");
-            Reporter.log("Got Job execution id: " + lastExecutionId + "<p>");
+            logger.info("Got Job instance id: " + jobInstanceId + "<p>");
+            logger.info("Got Job execution id: " + lastExecutionId + "<p>");
             {
-                Reporter.log("Create job parameters for execution #2:<p>");
+                logger.info("Create job parameters for execution #2:<p>");
                 Properties restartJobParameters = new Properties(jobParams);
-                Reporter.log("execution.number=2<p>");
-                Reporter.log("app.arraysize=30<p>");
+                logger.info("execution.number=2<p>");
+                logger.info("app.arraysize=30<p>");
                 
                 restartJobParameters.put("execution.number", "2");
                 restartJobParameters.put("app.checkpoint.position" , "10");
                 restartJobParameters.put("app.arraysize", "30");
-                Reporter.log("Invoke restartJobAndWaitForResult with execution id: " + lastExecutionId + "<p>");
+                logger.info("Invoke restartJobAndWaitForResult with execution id: " + lastExecutionId + "<p>");
                 TCKJobExecutionWrapper exec = jobOp.restartJobAndWaitForResult(lastExecutionId, restartJobParameters);
                 lastExecutionId = exec.getExecutionId();
-                Reporter.log("execution #2 JobExecution getBatchStatus()=" + exec.getBatchStatus() + "<p>");
-                Reporter.log("execution #2 JobExecution getExitStatus()=" + exec.getExitStatus() + "<p>");
-                Reporter.log("execution #2 Job instance id=" + exec.getInstanceId() + "<p>");
+                logger.info("execution #2 JobExecution getBatchStatus()=" + exec.getBatchStatus() + "<p>");
+                logger.info("execution #2 JobExecution getExitStatus()=" + exec.getExitStatus() + "<p>");
+                logger.info("execution #2 Job instance id=" + exec.getInstanceId() + "<p>");
                 assertWithMessage("Testing execution #2", BatchStatus.COMPLETED, exec.getBatchStatus());
                 assertWithMessage("Testing execution #2", "COMPLETED", exec.getExitStatus());
                 assertWithMessage("Testing execution #2", jobInstanceId, exec.getInstanceId());
@@ -461,27 +448,27 @@ public class ChunkTests {
      *                 job completes successfully. 
      */
     @Test
-    @org.junit.Test
+
     public void testChunkDefaultItemCount() throws Exception {
         String METHOD = "testChunkDefaultItemCount";
 
         try {
-            Reporter.log("Create job parameters for execution #1:<p>");
+            logger.info("Create job parameters for execution #1:<p>");
             Properties jobParams = new Properties();
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("readrecord.fail=40<p>");
-            Reporter.log("app.arraysize=30<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("readrecord.fail=40<p>");
+            logger.info("app.arraysize=30<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("app.checkpoint.position" , "0");
             jobParams.put("readrecord.fail", "40");
             jobParams.put("app.arraysize", "30");
 
-            Reporter.log("Locate job XML file: chunksizeDEFAULTcommitIntervalDEFAULT.xml<p>");
+            logger.info("Locate job XML file: chunksizeDEFAULTcommitIntervalDEFAULT.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             JobExecution execution1 = jobOp.startJobAndWaitForResult("chunksizeDEFAULTcommitIntervalDEFAULT", jobParams);
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.COMPLETED, execution1.getBatchStatus());
             assertWithMessage("Testing execution #1", "buffer size = 10", execution1.getExitStatus());
         } catch (Exception e) {
@@ -507,18 +494,18 @@ public class ChunkTests {
      *                  test that the job completes successfully.
      */
     @Test
-    @org.junit.Test
+
     public void testChunkRestartCustomCheckpoint() throws Exception {
         String METHOD = "testChunkRestartCustomCheckpoint";
 
         try {
-            Reporter.log("Create job parameters for execution #1:<p>");
+            logger.info("Create job parameters for execution #1:<p>");
             Properties jobParams = new Properties();
-            Reporter.log("execution.number=2<p>");
-            Reporter.log("readrecord.fail=12<p>");
-            Reporter.log("app.arraysize=30<p>");
-            Reporter.log("app.writepoints=0,4,9,13,15,20,22,27,30<p>");
-            Reporter.log("app.next.writepoints=9,13,15,20,22,27,30<p>");
+            logger.info("execution.number=2<p>");
+            logger.info("readrecord.fail=12<p>");
+            logger.info("app.arraysize=30<p>");
+            logger.info("app.writepoints=0,4,9,13,15,20,22,27,30<p>");
+            logger.info("app.next.writepoints=9,13,15,20,22,27,30<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("readrecord.fail", "12");
             jobParams.put("app.checkpoint.position" , "0");
@@ -526,35 +513,35 @@ public class ChunkTests {
             jobParams.put("app.writepoints", "0,4,9,13,15,20,22,27,30");
             jobParams.put("app.next.writepoints", "9,13,15,20,22,27,30");
 
-            Reporter.log("Locate job XML file: chunkCustomCheckpoint.xml<p>");
+            logger.info("Locate job XML file: chunkCustomCheckpoint.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             TCKJobExecutionWrapper execution1 = jobOp.startJobAndWaitForResult("chunkCustomCheckpoint", jobParams);
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.FAILED, execution1.getBatchStatus());
             assertWithMessage("Testing execution #1", "FAILED", execution1.getExitStatus());
 
             long jobInstanceId = execution1.getInstanceId();
             long lastExecutionId = execution1.getExecutionId();
-            Reporter.log("Got Job instance id: " + jobInstanceId + "<p>");
-            Reporter.log("Got Job execution id: " + lastExecutionId + "<p>");
+            logger.info("Got Job instance id: " + jobInstanceId + "<p>");
+            logger.info("Got Job execution id: " + lastExecutionId + "<p>");
             {
-                Reporter.log("Create job parameters for execution #2:<p>");
+                logger.info("Create job parameters for execution #2:<p>");
                 Properties restartJobParameters = new Properties(jobParams);
-                Reporter.log("execution.number=2<p>");
-                Reporter.log("app.arraysize=30<p>");
-                Reporter.log("app.writepoints=9,13,15,20,22,27,30<p>");
+                logger.info("execution.number=2<p>");
+                logger.info("app.arraysize=30<p>");
+                logger.info("app.writepoints=9,13,15,20,22,27,30<p>");
                 restartJobParameters.put("execution.number", "2");
                 restartJobParameters.put("app.checkpoint.position" , "9");
                 restartJobParameters.put("app.arraysize", "30");
                 restartJobParameters.put("app.writepoints", "9,13,15,20,22,27,30");
-                Reporter.log("Invoke restartJobAndWaitForResult with execution id: " + lastExecutionId + "<p>");
+                logger.info("Invoke restartJobAndWaitForResult with execution id: " + lastExecutionId + "<p>");
                 TCKJobExecutionWrapper exec = jobOp.restartJobAndWaitForResult(lastExecutionId, restartJobParameters);
                 lastExecutionId = exec.getExecutionId();
-                Reporter.log("execution #2 JobExecution getBatchStatus()=" + exec.getBatchStatus() + "<p>");
-                Reporter.log("execution #2 JobExecution getExitStatus()=" + exec.getExitStatus() + "<p>");
-                Reporter.log("execution #2 Job instance id=" + exec.getInstanceId() + "<p>");
+                logger.info("execution #2 JobExecution getBatchStatus()=" + exec.getBatchStatus() + "<p>");
+                logger.info("execution #2 JobExecution getExitStatus()=" + exec.getExitStatus() + "<p>");
+                logger.info("execution #2 Job instance id=" + exec.getInstanceId() + "<p>");
                 assertWithMessage("Testing execution #2", BatchStatus.COMPLETED, exec.getBatchStatus());
                 assertWithMessage("Testing execution #2", "COMPLETED", exec.getExitStatus());
                 assertWithMessage("Testing execution #2", jobInstanceId, exec.getInstanceId());
@@ -579,29 +566,29 @@ public class ChunkTests {
      *                  test that the job completes successfully.     
      */
     @Test
-    @org.junit.Test
+
     public void testChunkTimeBasedDefaultCheckpoint() throws Exception {
         String METHOD = "testChunkTimeBasedDefaultCheckpoint";
         
         String DEFAULT_SLEEP_TIME = "500";
 
         try {
-            Reporter.log("Create job parameters for execution #1:<p>");
+            logger.info("Create job parameters for execution #1:<p>");
             Properties jobParams = new Properties();
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("readrecord.fail=31<p>");
-            Reporter.log("app.arraysize=30<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("readrecord.fail=31<p>");
+            logger.info("app.arraysize=30<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("readrecord.fail", "31");
             jobParams.put("app.arraysize", "30");
             jobParams.put("app.sleeptime", System.getProperty("ChunkTests.testChunkTimeBasedDefaultCheckpoint.sleep",DEFAULT_SLEEP_TIME));
 
-            Reporter.log("Locate job XML file: chunkTimeBasedDefaultCheckpoint.xml<p>");
+            logger.info("Locate job XML file: chunkTimeBasedDefaultCheckpoint.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             JobExecution execution1 = jobOp.startJobAndWaitForResult("chunkTimeBasedDefaultCheckpoint", jobParams);
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.COMPLETED, execution1.getBatchStatus());
             String exitStatus = execution1.getExitStatus();
 	        assertWithMessage("Testing execution #1", (exitStatus.equals("TRUE: 0") || exitStatus.equals("TRUE: 1")));
@@ -624,30 +611,30 @@ public class ChunkTests {
      *                  test that the job completes successfully.     
      */
     @Test
-    @org.junit.Test
+
     public void testChunkTimeBasedTimeLimit0() throws Exception {
         String METHOD = "testChunkTimeBasedDefaultCheckpoint";
         
         String DEFAULT_SLEEP_TIME = "500";
 
         try {
-            Reporter.log("Create job parameters for execution #1:<p>");
+            logger.info("Create job parameters for execution #1:<p>");
             Properties jobParams = new Properties();
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("readrecord.fail=31<p>");
-            Reporter.log("app.arraysize=30<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("readrecord.fail=31<p>");
+            logger.info("app.arraysize=30<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("readrecord.fail", "31");
             jobParams.put("app.arraysize", "30");
             
             jobParams.put("app.sleeptime", System.getProperty("ChunkTests.testChunkTimeBasedTimeLimit0.sleep",DEFAULT_SLEEP_TIME));
 
-            Reporter.log("Locate job XML file: chunkTimeLimit0.xml<p>");
+            logger.info("Locate job XML file: chunkTimeLimit0.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             JobExecution execution1 = jobOp.startJobAndWaitForResult("chunkTimeLimit0", jobParams);
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.COMPLETED, execution1.getBatchStatus());
             String exitStatus = execution1.getExitStatus();
 	        assertWithMessage("Testing execution #1", (exitStatus.equals("TRUE: 0") || exitStatus.equals("TRUE: 1")));
@@ -673,7 +660,7 @@ public class ChunkTests {
      *                  test that the job completes successfully.     
      */
     @Test
-    @org.junit.Test
+
     public void testChunkTimeBased10Seconds() throws Exception {
     	
     	 String METHOD = "testChunkTimeBased10Seconds";
@@ -693,7 +680,7 @@ public class ChunkTests {
 	        String exitStatus = execution1.getExitStatus();
 	        assertWithMessage("Testing execution #1", (exitStatus.equals("TRUE: 9") || exitStatus.equals("TRUE: 10") || exitStatus.equals("TRUE: 11")));
 	
-	        Reporter.log("exit status = " + execution1.getExitStatus() + "<p>");
+	        logger.info("exit status = " + execution1.getExitStatus() + "<p>");
     	 } catch (Exception e) {
              handleException(METHOD, e);
          }
@@ -716,18 +703,18 @@ public class ChunkTests {
      *                  test that the job completes successfully.     
      */
     @Test
-    @org.junit.Test
+
     public void testChunkRestartTimeBasedCheckpoint() throws Exception {
         String METHOD = "testChunkRestartTimeBasedCheckpoint";
         
         String DEFAULT_SLEEP_TIME = "500";
 
         try {
-            Reporter.log("Create job parameters for execution #1:<p>");
+            logger.info("Create job parameters for execution #1:<p>");
             Properties jobParams = new Properties();
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("readrecord.fail=12<p>");
-            Reporter.log("app.arraysize=30<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("readrecord.fail=12<p>");
+            logger.info("app.arraysize=30<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("readrecord.fail", "12");
             jobParams.put("app.arraysize", "30");
@@ -735,25 +722,25 @@ public class ChunkTests {
 
 
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             TCKJobExecutionWrapper execution1 = jobOp.startJobAndWaitForResult("chunkTimeBasedCheckpoint", jobParams);
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.FAILED, execution1.getBatchStatus());
             assertWithMessage("Testing execution #1", "FALSE: 0", execution1.getExitStatus());
 
             long jobInstanceId = execution1.getInstanceId();
             long lastExecutionId = execution1.getExecutionId();
-            Reporter.log("Got Job instance id: " + jobInstanceId + "<p>");
-            Reporter.log("Got Job execution id: " + lastExecutionId + "<p>");
+            logger.info("Got Job instance id: " + jobInstanceId + "<p>");
+            logger.info("Got Job execution id: " + lastExecutionId + "<p>");
 
             {
-                Reporter.log("Invoke restartJobAndWaitForResult with execution id: " + lastExecutionId + "<p>");
+                logger.info("Invoke restartJobAndWaitForResult with execution id: " + lastExecutionId + "<p>");
                 TCKJobExecutionWrapper exec = jobOp.restartJobAndWaitForResult(lastExecutionId, jobParams);
                 lastExecutionId = exec.getExecutionId();
-                Reporter.log("execution #2 JobExecution getBatchStatus()=" + exec.getBatchStatus() + "<p>");
-                Reporter.log("execution #2 JobExecution getExitStatus()=" + exec.getExitStatus() + "<p>");
-                Reporter.log("execution #2 Job instance id=" + exec.getInstanceId() + "<p>");
+                logger.info("execution #2 JobExecution getBatchStatus()=" + exec.getBatchStatus() + "<p>");
+                logger.info("execution #2 JobExecution getExitStatus()=" + exec.getExitStatus() + "<p>");
+                logger.info("execution #2 Job instance id=" + exec.getInstanceId() + "<p>");
                 assertWithMessage("Testing execution #2", BatchStatus.COMPLETED, exec.getBatchStatus());
                 String exitStatus = exec.getExitStatus();
     	        assertWithMessage("Testing execution #2", (exitStatus.equals("TRUE: 9") || exitStatus.equals("TRUE: 10") || exitStatus.equals("TRUE: 11")));
@@ -783,7 +770,7 @@ public class ChunkTests {
      *                  test that the job completes successfully.     
      */
     @Test
-    @org.junit.Test
+
     public void testChunkRestartTimeBasedDefaultCheckpoint() throws Exception {
 
         String METHOD = "testChunkRestartTimeBasedDefaultCheckpoint";
@@ -791,22 +778,22 @@ public class ChunkTests {
         String DEFAULT_SLEEP_TIME = "500";
         
         try {
-            Reporter.log("Create job parameters for execution #1:<p>");
+            logger.info("Create job parameters for execution #1:<p>");
             Properties jobParams = new Properties();
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("readrecord.fail=2<p>");
-            Reporter.log("app.arraysize=30<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("readrecord.fail=2<p>");
+            logger.info("app.arraysize=30<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("readrecord.fail", "2");
             jobParams.put("app.arraysize", "30");
             jobParams.put("app.sleeptime", System.getProperty("ChunkTests.testChunkRestartTimeBasedDefaultCheckpoint.sleep",DEFAULT_SLEEP_TIME));
 
-            Reporter.log("Locate job XML file: chunkTimeBasedDefaultCheckpoint.xml<p>");
+            logger.info("Locate job XML file: chunkTimeBasedDefaultCheckpoint.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             TCKJobExecutionWrapper execution1 = jobOp.startJobAndWaitForResult("chunkTimeBasedDefaultCheckpoint", jobParams);
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.FAILED, execution1.getBatchStatus());
             assertWithMessage("Testing execution #1", "TRUE: 0", execution1.getExitStatus());
 
@@ -814,16 +801,16 @@ public class ChunkTests {
             JobInstance jobInstance = jobOp.getJobInstance(execution1.getExecutionId());
             jobInstanceId = jobInstance.getInstanceId();
             long lastExecutionId = execution1.getExecutionId();
-            Reporter.log("Got Job instance id: " + jobInstanceId + "<p>");
-            Reporter.log("Got Job execution id: " + lastExecutionId + "<p>");
+            logger.info("Got Job instance id: " + jobInstanceId + "<p>");
+            logger.info("Got Job execution id: " + lastExecutionId + "<p>");
             {
 
-                Reporter.log("Invoke restartJobAndWaitForResult with execution id: " + lastExecutionId + "<p>");
+                logger.info("Invoke restartJobAndWaitForResult with execution id: " + lastExecutionId + "<p>");
                 TCKJobExecutionWrapper exec = jobOp.restartJobAndWaitForResult(lastExecutionId, jobParams);
                 lastExecutionId = exec.getExecutionId();
-                Reporter.log("execution #2 JobExecution getBatchStatus()=" + exec.getBatchStatus() + "<p>");
-                Reporter.log("execution #2 JobExecution getExitStatus()=" + exec.getExitStatus() + "<p>");
-                Reporter.log("execution #2 Job instance id=" + exec.getInstanceId() + "<p>");
+                logger.info("execution #2 JobExecution getBatchStatus()=" + exec.getBatchStatus() + "<p>");
+                logger.info("execution #2 JobExecution getExitStatus()=" + exec.getExitStatus() + "<p>");
+                logger.info("execution #2 Job instance id=" + exec.getInstanceId() + "<p>");
                 assertWithMessage("Testing execution #2", BatchStatus.COMPLETED, exec.getBatchStatus());
                 assertWithMessage("Testing execution #2", "TRUE: 0", exec.getExitStatus());
                 assertWithMessage("Testing execution #2", jobInstanceId, exec.getInstanceId());
@@ -853,28 +840,28 @@ public class ChunkTests {
      *                  test that the job completes fails and that the application recognized the skippable exception 
      *                  that extends the unskippable is not treated as skippable.     
      */
-    @org.junit.Test
-	@Test(enabled=false) // Disabling per Bug 5403
-	@Ignore("Bug 5403.  Decided to exclude this test. Hopefully will introduce a modified version in 1.1")
+
+	@Test // Disabling per Bug 5403
+	@Disabled("Bug 5403.  Decided to exclude this test. Hopefully will introduce a modified version in 1.1")
     public void testChunkSkipMultipleExceptions() throws Exception {
 
         String METHOD = "testChunkSkipRead";
         try {
-            Reporter.log("Create job parameters for execution #1:<p>");
+            logger.info("Create job parameters for execution #1:<p>");
             Properties jobParams = new Properties();
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("readrecord.fail=1,3<p>");
-            Reporter.log("app.arraysize=30<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("readrecord.fail=1,3<p>");
+            logger.info("app.arraysize=30<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("readrecord.fail", "1,3");
             jobParams.put("app.arraysize", "30");
 
-            Reporter.log("Locate job XML file: chunkSkipMultipleExceptions.xml<p>");
+            logger.info("Locate job XML file: chunkSkipMultipleExceptions.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             JobExecution execution1 = jobOp.startJobAndWaitForResult("chunkSkipMultipleExceptions", jobParams);
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.FAILED, execution1.getBatchStatus());
             assertWithMessage("Testing execution #1", MySkipReadListener.GOOD_EXIT_STATUS, execution1.getExitStatus());
         } catch (Exception e) {
@@ -899,26 +886,26 @@ public class ChunkTests {
      *                  test that the job completes successfully and that the application recognized the exceptions as skippable     
      */
     @Test
-    @org.junit.Test
+
     public void testChunkSkipRead() throws Exception {
 
         String METHOD = "testChunkSkipRead";
         try {
-            Reporter.log("Create job parameters for execution #1:<p>");
+            logger.info("Create job parameters for execution #1:<p>");
             Properties jobParams = new Properties();
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("readrecord.fail=1,3<p>");
-            Reporter.log("app.arraysize=30<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("readrecord.fail=1,3<p>");
+            logger.info("app.arraysize=30<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("readrecord.fail", "1,3");
             jobParams.put("app.arraysize", "30");
 
-            Reporter.log("Locate job XML file: chunkSkipInitialTest.xml<p>");
+            logger.info("Locate job XML file: chunkSkipInitialTest.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             JobExecution execution1 = jobOp.startJobAndWaitForResult("chunkSkipInitialTest", jobParams);
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.COMPLETED, execution1.getBatchStatus());
             assertWithMessage("Testing execution #1", MySkipReadListener.GOOD_EXIT_STATUS, execution1.getExitStatus());
         } catch (Exception e) {
@@ -944,25 +931,25 @@ public class ChunkTests {
      *                  and that the item was passed to the skip listener.     
      */
     @Test
-    @org.junit.Test
+
     public void testChunkSkipProcess() throws Exception {
         String METHOD = "testChunkSkipProcess";
         try {
-            Reporter.log("Create job parameters for execution #1:<p>");
+            logger.info("Create job parameters for execution #1:<p>");
             Properties jobParams = new Properties();
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("processrecord.fail=7,13<p>");
-            Reporter.log("app.arraysize=30<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("processrecord.fail=7,13<p>");
+            logger.info("app.arraysize=30<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("processrecord.fail", "7,13");
             jobParams.put("app.arraysize", "30");
 
-            Reporter.log("Locate job XML file: chunkSkipInitialTest.xml<p>");
+            logger.info("Locate job XML file: chunkSkipInitialTest.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             JobExecution execution1 = jobOp.startJobAndWaitForResult("chunkSkipInitialTest", jobParams);
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.COMPLETED, execution1.getBatchStatus());
             assertWithMessage("Testing execution #1", MySkipProcessListener.GOOD_EXIT_STATUS, execution1.getExitStatus());
         } catch (Exception e) {
@@ -987,26 +974,26 @@ public class ChunkTests {
      *                  and that the item was passed to the skip listener.
      */
     @Test
-    @org.junit.Test
+
     public void testChunkSkipWrite() throws Exception {
         String METHOD = "testChunkSkipWrite";
         try {
-            Reporter.log("Create job parameters for execution #1:<p>");
+            logger.info("Create job parameters for execution #1:<p>");
             Properties jobParams = new Properties();
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("writerecord.fail=1,3<p>");
-            Reporter.log("app.arraysize=30<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("writerecord.fail=1,3<p>");
+            logger.info("app.arraysize=30<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("writerecord.fail", "1,3");
             jobParams.put("app.arraysize", "30");
 
-            Reporter.log("Locate job XML file: chunkSkipInitialTest.xml<p>");
+            logger.info("Locate job XML file: chunkSkipInitialTest.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             JobExecution execution1 = jobOp.startJobAndWaitForResult("chunkSkipInitialTest", jobParams);
 
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.COMPLETED, execution1.getBatchStatus());
             assertWithMessage("Testing execution #1", MySkipWriteListener.GOOD_EXIT_STATUS, execution1.getExitStatus());
         } catch (Exception e) {
@@ -1031,63 +1018,63 @@ public class ChunkTests {
      *                  test that the job completes successfully and that the application recognized the exceptions as skippable     
      */
     @Test
-    @org.junit.Test
+
     public void testChunkSkipOnError() throws Exception {
 
         String METHOD = "testChunkSkipOnError";
         try {
-            Reporter.log("Create job parameters for execution #1:<p>");
+            logger.info("Create job parameters for execution #1:<p>");
             Properties jobParams = new Properties();
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("readrecord.fail=1,3<p>");
-            Reporter.log("app.arraysize=30<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("readrecord.fail=1,3<p>");
+            logger.info("app.arraysize=30<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("readrecord.fail", "1,3");
             jobParams.put("app.arraysize", "30");
 
-            Reporter.log("Locate job XML file: chunkSkipOnErrorTest.xml<p>");
+            logger.info("Locate job XML file: chunkSkipOnErrorTest.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             JobExecution execution1 = jobOp.startJobAndWaitForResult("chunkSkipOnErrorTest", jobParams);
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.COMPLETED, execution1.getBatchStatus());
             assertWithMessage("Testing execution #1", "MyItemReadListenerImpl.onReadError", execution1.getExitStatus());
             
             //process skip
             jobParams = new Properties();
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("processrecord.fail=7,13<p>");
-            Reporter.log("app.arraysize=30<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("processrecord.fail=7,13<p>");
+            logger.info("app.arraysize=30<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("processrecord.fail", "7,13");
             jobParams.put("app.arraysize", "30");
 
-            Reporter.log("Locate job XML file: chunkSkipOnErrorTest.xml<p>");
+            logger.info("Locate job XML file: chunkSkipOnErrorTest.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             JobExecution execution2 = jobOp.startJobAndWaitForResult("chunkSkipOnErrorTest", jobParams);
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution2.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution2.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution2.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution2.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.COMPLETED, execution2.getBatchStatus());
             assertWithMessage("Testing execution #1", "MyItemProcessListenerImpl.onProcessError", execution2.getExitStatus());
             
             //write skip
             jobParams = new Properties();
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("writerecord.fail=1,3<p>");
-            Reporter.log("app.arraysize=30<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("writerecord.fail=1,3<p>");
+            logger.info("app.arraysize=30<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("writerecord.fail", "1,3");
             jobParams.put("app.arraysize", "30");
 
-            Reporter.log("Locate job XML file: chunkSkipOnErrorTest.xml<p>");
+            logger.info("Locate job XML file: chunkSkipOnErrorTest.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             JobExecution execution3 = jobOp.startJobAndWaitForResult("chunkSkipOnErrorTest", jobParams);
 
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution3.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution3.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution3.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution3.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.COMPLETED, execution3.getBatchStatus());
             assertWithMessage("Testing execution #1", "MyItemWriteListenerImpl.onWriteError", execution3.getExitStatus());
             
@@ -1113,63 +1100,63 @@ public class ChunkTests {
      *                  test that the job completes successfully and that the listener's onError method is called by the runtime.    
      */
     @Test
-    @org.junit.Test
+
     public void testChunkRetryOnError() throws Exception {
 
         String METHOD = "testChunkRetryOnError";
         try {
-            Reporter.log("Create job parameters for execution #1:<p>");
+            logger.info("Create job parameters for execution #1:<p>");
             Properties jobParams = new Properties();
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("readrecord.fail=1,3<p>");
-            Reporter.log("app.arraysize=30<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("readrecord.fail=1,3<p>");
+            logger.info("app.arraysize=30<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("readrecord.fail", "1,3");
             jobParams.put("app.arraysize", "30");
 
-            Reporter.log("Locate job XML file: chunkRetryOnError.xml<p>");
+            logger.info("Locate job XML file: chunkRetryOnError.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             JobExecution execution1 = jobOp.startJobAndWaitForResult("chunkRetryOnError", jobParams);
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.COMPLETED, execution1.getBatchStatus());
             assertWithMessage("Testing execution #1", "MyItemReadListenerImpl.onReadError", execution1.getExitStatus());
             
             //process skip
             jobParams = new Properties();
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("processrecord.fail=7,13<p>");
-            Reporter.log("app.arraysize=30<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("processrecord.fail=7,13<p>");
+            logger.info("app.arraysize=30<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("processrecord.fail", "7,13");
             jobParams.put("app.arraysize", "30");
 
-            Reporter.log("Locate job XML file: chunkRetryOnError.xml<p>");
+            logger.info("Locate job XML file: chunkRetryOnError.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             JobExecution execution2 = jobOp.startJobAndWaitForResult("chunkRetryOnError", jobParams);
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution2.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution2.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution2.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution2.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.COMPLETED, execution2.getBatchStatus());
             assertWithMessage("Testing execution #1", "MyItemProcessListenerImpl.onProcessError", execution2.getExitStatus());
             
             //write skip
             jobParams = new Properties();
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("writerecord.fail=1,3<p>");
-            Reporter.log("app.arraysize=30<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("writerecord.fail=1,3<p>");
+            logger.info("app.arraysize=30<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("writerecord.fail", "1,3");
             jobParams.put("app.arraysize", "30");
 
-            Reporter.log("Locate job XML file: chunkRetryOnError.xml<p>");
+            logger.info("Locate job XML file: chunkRetryOnError.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             JobExecution execution3 = jobOp.startJobAndWaitForResult("chunkRetryOnError", jobParams);
 
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution3.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution3.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution3.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution3.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.COMPLETED, execution3.getBatchStatus());
             assertWithMessage("Testing execution #1", "MyItemWriteListenerImpl.onWriteError", execution3.getExitStatus());
             
@@ -1195,27 +1182,27 @@ public class ChunkTests {
      *                  test that the job fails but the skip-limit was recognized.     
      */
     @Test
-    @org.junit.Test
+
     public void testChunkSkipReadExceedSkip() throws Exception {
         String METHOD = "testChunkSkipReadExceedSkip";
 
         try {
-            Reporter.log("Create job parameters for execution #1:<p>");
+            logger.info("Create job parameters for execution #1:<p>");
             Properties jobParams = new Properties();
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("processrecord.fail=1,2<p>");
-            Reporter.log("app.arraysize=30<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("processrecord.fail=1,2<p>");
+            logger.info("app.arraysize=30<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("readrecord.fail", "1,2");
             jobParams.put("app.arraysize", "30");
 
-            Reporter.log("Locate job XML file: chunkSkipExceededTest.xml<p>");
+            logger.info("Locate job XML file: chunkSkipExceededTest.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             JobExecution execution1 = jobOp.startJobAndWaitForResult("chunkSkipExceededTest", jobParams);
 
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.FAILED, execution1.getBatchStatus());
             assertWithMessage("Testing execution #1", MySkipReadListener.GOOD_EXIT_STATUS, execution1.getExitStatus());
         } catch (Exception e) {
@@ -1240,28 +1227,28 @@ public class ChunkTests {
      *                  test that the job fails but the skip-limit was recognized.     
      */
     @Test
-    @org.junit.Test
+
     public void testChunkSkipProcessExceedSkip() throws Exception {
 
         String METHOD = "testChunkSkipProcessExceedSkip";
 
         try {
-            Reporter.log("Create job parameters for execution #1:<p>");
+            logger.info("Create job parameters for execution #1:<p>");
             Properties jobParams = new Properties();
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("processrecord.fail=5,7<p>");
-            Reporter.log("app.arraysize=30<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("processrecord.fail=5,7<p>");
+            logger.info("app.arraysize=30<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("processrecord.fail", "5,7");
             jobParams.put("app.arraysize", "30");
 
-            Reporter.log("Locate job XML file: chunkSkipExceededTest.xml<p>");
+            logger.info("Locate job XML file: chunkSkipExceededTest.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             JobExecution execution1 = jobOp.startJobAndWaitForResult("chunkSkipExceededTest", jobParams);
 
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.FAILED, execution1.getBatchStatus());
             assertWithMessage("Testing execution #1", MySkipProcessListener.GOOD_EXIT_STATUS, execution1.getExitStatus());
         } catch (Exception e) {
@@ -1286,27 +1273,27 @@ public class ChunkTests {
      *                  test that the job fails but the skip-limit was recognized.     
      */
     @Test
-    @org.junit.Test
+
     public void testChunkSkipWriteExceedSkip() throws Exception {
         String METHOD = "testChunkSkipWriteExceedSkip";
 
         try {
-            Reporter.log("Create job parameters for execution #1:<p>");
+            logger.info("Create job parameters for execution #1:<p>");
             Properties jobParams = new Properties();
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("writerecord.fail=2,8<p>");
-            Reporter.log("app.arraysize=30<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("writerecord.fail=2,8<p>");
+            logger.info("app.arraysize=30<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("writerecord.fail", "2,8");
             jobParams.put("app.arraysize", "30");
 
-            Reporter.log("Locate job XML file: chunkSkipExceededTest.xml<p>");
+            logger.info("Locate job XML file: chunkSkipExceededTest.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             JobExecution execution1 = jobOp.startJobAndWaitForResult("chunkSkipExceededTest", jobParams);
 
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.FAILED, execution1.getBatchStatus());
             assertWithMessage("Testing execution #1", MySkipWriteListener.GOOD_EXIT_STATUS, execution1.getExitStatus());
         } catch (Exception e) {
@@ -1332,27 +1319,27 @@ public class ChunkTests {
      *                  test that the job fails but the final exception was non skippable was recognized.     
      */
     @Test
-    @org.junit.Test
+
     public void testChunkSkipReadNoSkipChildEx() throws Exception {
         String METHOD = "testChunkSkipReadNoSkipChildEx";
 
         try {
-            Reporter.log("Create job parameters for execution #1:<p>");
+            logger.info("Create job parameters for execution #1:<p>");
             Properties jobParams = new Properties();
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("writerecord.fail=1,2,3<p>");
-            Reporter.log("app.arraysize=30<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("writerecord.fail=1,2,3<p>");
+            logger.info("app.arraysize=30<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("readrecord.fail", "1,2,3");
             jobParams.put("app.arraysize", "30");
 
-            Reporter.log("Locate job XML file: chunkSkipNoSkipChildExTest.xml<p>");
+            logger.info("Locate job XML file: chunkSkipNoSkipChildExTest.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             JobExecution execution1 = jobOp.startJobAndWaitForResult("chunkSkipNoSkipChildExTest", jobParams);
 
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.FAILED, execution1.getBatchStatus());
             assertWithMessage("Testing execution #1", MySkipReadListener.GOOD_EXIT_STATUS, execution1.getExitStatus());
         } catch (Exception e) {
@@ -1377,27 +1364,27 @@ public class ChunkTests {
      *                  test that the job succeeds.    
      */
     @Test
-    @org.junit.Test
+
     public void testChunkRetryRead() throws Exception {
         String METHOD = "testChunkRetryRead";
 
         try {
-            Reporter.log("Create job parameters for execution #1:<p>");
+            logger.info("Create job parameters for execution #1:<p>");
             Properties jobParams = new Properties();
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("writerecord.fail=8,13,22<p>");
-            Reporter.log("app.arraysize=30<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("writerecord.fail=8,13,22<p>");
+            logger.info("app.arraysize=30<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("readrecord.fail", "8,13,22");
             jobParams.put("app.arraysize", "30");
 
-            Reporter.log("Locate job XML file: chunkRetryInitialTest.xml<p>");
+            logger.info("Locate job XML file: chunkRetryInitialTest.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             JobExecution execution1 = jobOp.startJobAndWaitForResult("chunkRetryInitialTest", jobParams);
 
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.COMPLETED, execution1.getBatchStatus());
             assertWithMessage("Testing execution #1", "COMPLETED", execution1.getExitStatus());
         } catch (Exception e) {
@@ -1422,28 +1409,28 @@ public class ChunkTests {
      *                  as unretryable itself.
      *                  test that the job completes fails and that the application recognized the retryable exception that extends the unretryable is not treated as retryable.  
      */
-    @org.junit.Test
-	@Test(enabled=false) // Disabling per Bug 5403
-	@Ignore("Bug 5403.  Decided to exclude this test. Hopefully will introduce a modified version in 1.1")
+
+	@Test // Disabling per Bug 5403
+	@Disabled("Bug 5403.  Decided to exclude this test. Hopefully will introduce a modified version in 1.1")
     public void testChunkRetryMultipleExceptions() throws Exception {
 
         String METHOD = "testChunkRetryMultipleExceptions";
         try {
-            Reporter.log("Create job parameters for execution #1:<p>");
+            logger.info("Create job parameters for execution #1:<p>");
             Properties jobParams = new Properties();
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("readrecord.fail=1,3<p>");
-            Reporter.log("app.arraysize=30<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("readrecord.fail=1,3<p>");
+            logger.info("app.arraysize=30<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("readrecord.fail", "1,3,5");
             jobParams.put("app.arraysize", "30");
 
-            Reporter.log("Locate job XML file: chunkRetryMultipleExceptions.xml<p>");
+            logger.info("Locate job XML file: chunkRetryMultipleExceptions.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             JobExecution execution1 = jobOp.startJobAndWaitForResult("chunkRetryMultipleExceptions", jobParams);
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.FAILED, execution1.getBatchStatus());
             assertWithMessage("Testing execution #1", MyMultipleExceptionsRetryReadListener.GOOD_EXIT_STATUS, execution1.getExitStatus());
         } catch (Exception e) {
@@ -1472,73 +1459,73 @@ public class ChunkTests {
      *                  test that each job succeeds and that the appropriate listener was called.    
      */
     @Test
-    @org.junit.Test
+
     public void testChunkItemListeners() throws Exception {
         String METHOD = "testChunkItemListeners";
 
         try {
-            Reporter.log("Create job parameters for execution #1:<p>");
+            logger.info("Create job parameters for execution #1:<p>");
             Properties jobParams = new Properties();
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("readrecord.fail=31<p>");
-            Reporter.log("app.arraysize=30<p>");
-            Reporter.log("app.writepoints=0,5,10,15,20,25,30<p>");
-            Reporter.log("app.listenertest=READ<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("readrecord.fail=31<p>");
+            logger.info("app.arraysize=30<p>");
+            logger.info("app.writepoints=0,5,10,15,20,25,30<p>");
+            logger.info("app.listenertest=READ<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("readrecord.fail", "31");
             jobParams.put("app.arraysize", "30");
             jobParams.put("app.writepoints", "0,5,10,15,20,25,30");
             jobParams.put("app.listenertest", "READ");
 
-            Reporter.log("Locate job XML file: testListeners.xml<p>");
+            logger.info("Locate job XML file: testListeners.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             JobExecution execution1 = jobOp.startJobAndWaitForResult("testListeners", jobParams);
 
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1 for the READ LISTENER", BatchStatus.COMPLETED, execution1.getBatchStatus());
             assertWithMessage("Testing execution #1 for the READ LISTENER", MyItemReadListenerImpl.GOOD_EXIT_STATUS,
                     execution1.getExitStatus());
 
-            Reporter.log("Create job parameters for execution #2:<p>");
+            logger.info("Create job parameters for execution #2:<p>");
             jobParams = new Properties();
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("readrecord.fail=31<p>");
-            Reporter.log("app.arraysize=30<p>");
-            Reporter.log("app.writepoints=0,5,10,15,20,25,30<p>");
-            Reporter.log("app.listenertest=PROCESS<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("readrecord.fail=31<p>");
+            logger.info("app.arraysize=30<p>");
+            logger.info("app.writepoints=0,5,10,15,20,25,30<p>");
+            logger.info("app.listenertest=PROCESS<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("readrecord.fail", "31");
             jobParams.put("app.arraysize", "30");
             jobParams.put("app.writepoints", "0,5,10,15,20,25,30");
             jobParams.put("app.listenertest", "PROCESS");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #2<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #2<p>");
             JobExecution execution2 = jobOp.startJobAndWaitForResult("testListeners", jobParams);
-            Reporter.log("execution #2 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #2 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #2 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #2 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #2 for the PROCESS LISTENER", BatchStatus.COMPLETED, execution2.getBatchStatus());
             assertWithMessage("Testing execution #2 for the PROCESS LISTENER", MyItemProcessListenerImpl.GOOD_EXIT_STATUS,
                     execution2.getExitStatus());
 
-            Reporter.log("Create job parameters for execution #3:<p>");
+            logger.info("Create job parameters for execution #3:<p>");
             jobParams = new Properties();
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("readrecord.fail=31<p>");
-            Reporter.log("app.arraysize=30<p>");
-            Reporter.log("app.writepoints=0,5,10,15,20,25,30<p>");
-            Reporter.log("app.listenertest=WRITE<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("readrecord.fail=31<p>");
+            logger.info("app.arraysize=30<p>");
+            logger.info("app.writepoints=0,5,10,15,20,25,30<p>");
+            logger.info("app.listenertest=WRITE<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("readrecord.fail", "31");
             jobParams.put("app.arraysize", "30");
             jobParams.put("app.writepoints", "0,5,10,15,20,25,30");
             jobParams.put("app.listenertest", "WRITE");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #3<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #3<p>");
             JobExecution execution3 = jobOp.startJobAndWaitForResult("testListeners", jobParams);
-            Reporter.log("execution #3 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #3 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #3 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #3 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #3 for the WRITE LISTENER", BatchStatus.COMPLETED, execution3.getBatchStatus());
             assertWithMessage("Testing execution #3 for the WRITE LISTENER", MyItemWriteListenerImpl.GOOD_EXIT_STATUS,
                     execution3.getExitStatus());
@@ -1567,55 +1554,55 @@ public class ChunkTests {
      *                  The Batch Artifact enforces that each listener (read, process and write) onError() methods are been called correctly by the runtime.    
      */
     @Test
-    @org.junit.Test
+
     public void testChunkItemListenersOnError() throws Exception {
         String METHOD = "testChunkItemListeners";
 
         try {
-            Reporter.log("Create job parameters for execution #1:<p>");
+            logger.info("Create job parameters for execution #1:<p>");
             Properties jobParams = new Properties();
             
-            Reporter.log("read.fail.immediate=true<p>");
+            logger.info("read.fail.immediate=true<p>");
         
             jobParams.put("read.fail.immediate", "true");
 
-            Reporter.log("Locate job XML file: testListeners.xml<p>");
+            logger.info("Locate job XML file: testListeners.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             JobExecution execution1 = jobOp.startJobAndWaitForResult("testListenersOnError", jobParams);
 
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1 for the READ LISTENER", BatchStatus.FAILED, execution1.getBatchStatus());
             assertWithMessage("Testing execution #1 for the READ LISTENER", "MyItemReadListenerImpl.onReadError",
                     execution1.getExitStatus());
 
-            Reporter.log("Create job parameters for execution #2:<p>");
+            logger.info("Create job parameters for execution #2:<p>");
             jobParams = new Properties();
-            Reporter.log("process.fail.immediate=true<p>");
+            logger.info("process.fail.immediate=true<p>");
             
             jobParams.put("process.fail.immediate", "true");
 
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #2<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #2<p>");
             JobExecution execution2 = jobOp.startJobAndWaitForResult("testListenersOnError", jobParams);
-            Reporter.log("execution #2 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #2 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #2 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #2 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #2 for the PROCESS LISTENER", BatchStatus.FAILED, execution2.getBatchStatus());
             assertWithMessage("Testing execution #2 for the PROCESS LISTENER", "MyItemProcessListenerImpl.onProcessError",
                     execution2.getExitStatus());
 
-            Reporter.log("Create job parameters for execution #3:<p>");
+            logger.info("Create job parameters for execution #3:<p>");
             jobParams = new Properties();
-            Reporter.log("write.fail.immediate=true<p>");
+            logger.info("write.fail.immediate=true<p>");
             
             jobParams.put("write.fail.immediate", "true");
 
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #3<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #3<p>");
             JobExecution execution3 = jobOp.startJobAndWaitForResult("testListenersOnError", jobParams);
-            Reporter.log("execution #3 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #3 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #3 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #3 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #3 for the WRITE LISTENER", BatchStatus.FAILED, execution3.getBatchStatus());
             assertWithMessage("Testing execution #3 for the WRITE LISTENER", "MyItemWriteListenerImpl.onWriteError",
                     execution3.getExitStatus());
@@ -1634,18 +1621,18 @@ public class ChunkTests {
      *                 Verify that persisted step data is available even if step did not complete.
      */
     @Test
-    @org.junit.Test
+
     public void testUserDataIsPersistedAfterCheckpoint() throws Exception {
 
         String METHOD = "testChunkRestartItemCount10";
         try {
-            Reporter.log("Create job parameters for execution #1:<p>");
+            logger.info("Create job parameters for execution #1:<p>");
             Properties jobParams = new Properties();
-            Reporter.log("execution.number=1<p>");
-            Reporter.log("readrecord.fail=12<p>");
-            Reporter.log("app.arraysize=30<p>");
-            Reporter.log("app.writepoints=0,5,10,15,20,25,30<p>");
-            Reporter.log("app.next.writepoints=0,5,10,15,20,25,30<p>");
+            logger.info("execution.number=1<p>");
+            logger.info("readrecord.fail=12<p>");
+            logger.info("app.arraysize=30<p>");
+            logger.info("app.writepoints=0,5,10,15,20,25,30<p>");
+            logger.info("app.next.writepoints=0,5,10,15,20,25,30<p>");
             jobParams.put("execution.number", "1");
             jobParams.put("readrecord.fail", "12");
             jobParams.put("app.arraysize", "30");
@@ -1653,12 +1640,12 @@ public class ChunkTests {
             jobParams.put("app.writepoints", "0,10,20,30");
             jobParams.put("app.next.writepoints", "10,20,30");
 
-            Reporter.log("Locate job XML file: chunkrestartCheckpt10.xml<p>");
+            logger.info("Locate job XML file: chunkrestartCheckpt10.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+            logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
             TCKJobExecutionWrapper execution1 = jobOp.startJobAndWaitForResult("chunkrestartCheckpt10", jobParams);
-            Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-            Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+            logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+            logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
             assertWithMessage("Testing execution #1", BatchStatus.FAILED, execution1.getBatchStatus());
             assertWithMessage("Testing execution #1", "FAILED", execution1.getExitStatus());
             
@@ -1683,25 +1670,25 @@ public class ChunkTests {
     
     private void showStepState(StepExecution step) {
 
-        Reporter.log("---------------------------<p>");
-        Reporter.log("getJobExecutionId(): " + step.getStepExecutionId() + " - ");
+        logger.info("---------------------------<p>");
+        logger.info("getJobExecutionId(): " + step.getStepExecutionId() + " - ");
 
         Metric[] metrics = step.getMetrics();
 
         for (int i = 0; i < metrics.length; i++) {
-            Reporter.log(metrics[i].getType() + ": " + metrics[i].getValue() + " - ");
+            logger.info(metrics[i].getType() + ": " + metrics[i].getValue() + " - ");
         }
 
-        Reporter.log("getStartTime(): " + step.getStartTime() + " - ");
-        Reporter.log("getEndTime(): " + step.getEndTime() + " - ");
-        Reporter.log("getBatchStatus(): " + step.getBatchStatus() + " - ");
-        Reporter.log("getExitStatus(): " + step.getExitStatus());
-        Reporter.log("---------------------------<p>");
+        logger.info("getStartTime(): " + step.getStartTime() + " - ");
+        logger.info("getEndTime(): " + step.getEndTime() + " - ");
+        logger.info("getBatchStatus(): " + step.getBatchStatus() + " - ");
+        logger.info("getExitStatus(): " + step.getExitStatus());
+        logger.info("---------------------------<p>");
     }
 
     private static void handleException(String methodName, Exception e) throws Exception {
-        Reporter.log("Caught exception: " + e.getMessage() + "<p>");
-        Reporter.log(methodName + " failed<p>");
+        logger.info("Caught exception: " + e.getMessage() + "<p>");
+        logger.info(methodName + " failed<p>");
         throw e;
     }
 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ContextAndListenerTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ContextAndListenerTests.java
@@ -31,32 +31,16 @@ import javax.batch.runtime.StepExecution;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
 
-import org.junit.BeforeClass;
-import org.testng.Reporter;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.*;
 
 public class ContextAndListenerTests {
 
 	private final static Logger logger = Logger.getLogger(ContextAndListenerTests.class.getName());
-	private static JobOperatorBridge jobOp = null;
+	private JobOperatorBridge jobOp = null;
 
 
-	public static void setup(String[] args, Properties props) throws Exception {
-
-		String METHOD = "setup";
-
-		try {
-			jobOp = new JobOperatorBridge();
-		} catch (Exception e) {
-			handleException(METHOD, e);
-		}
-	}
-
-	@BeforeMethod
-	@BeforeClass
-	public static void setUp() throws Exception {
+	@BeforeEach
+	public void setUp() throws Exception {
 		jobOp = new JobOperatorBridge();
 	}
 
@@ -66,29 +50,29 @@ public class ContextAndListenerTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test 
+ 
 	public void testExamineJobContextInArtifact() throws Exception {
 
 		String METHOD = "testExamineJobContextInArtifact()";
 
 		try {
 
-			Reporter.log("Locate job XML file: JobContextTestBatchlet.xml<p>");
+			logger.info("Locate job XML file: JobContextTestBatchlet.xml<p>");
 
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
-			Reporter.log("app.timeinterval=10<p>");
+			logger.info("app.timeinterval=10<p>");
 			jobParams.put("app.timeinterval", "10");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			JobExecution execution1 = jobOp.startJobAndWaitForResult("JobContextTestBatchlet", jobParams);
 		
 			
 			String testString = "JobName=job1;JobInstanceId=" + jobOp.getJobInstance(execution1.getExecutionId()).getInstanceId() + ";JobExecutionId=" + execution1.getExecutionId();
-			Reporter.log("EXPECTED JobExecution getBatchStatus()=COMPLETED<p>");
-			Reporter.log("ACTUAL JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
-			Reporter.log("EXPECTED JobExecution getExitStatus()="+testString+"<p>");
-			Reporter.log("ACTUAL JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
+			logger.info("EXPECTED JobExecution getBatchStatus()=COMPLETED<p>");
+			logger.info("ACTUAL JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
+			logger.info("EXPECTED JobExecution getExitStatus()="+testString+"<p>");
+			logger.info("ACTUAL JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
 			assertWithMessage("Testing batch status", BatchStatus.COMPLETED, execution1.getBatchStatus());
 			assertWithMessage("Testing exit status", testString, execution1.getExitStatus());
 		} catch (Exception e) {
@@ -102,21 +86,21 @@ public class ContextAndListenerTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test 
+ 
 	public void testExamineStepContextInArtifact() throws Exception {
 
 		String METHOD = "testExamineStepContextInArtifact()";
 
 		try {
 
-			Reporter.log("Locate job XML file: StepContextTestBatchlet.xml<p>");
+			logger.info("Locate job XML file: StepContextTestBatchlet.xml<p>");
 
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
-			Reporter.log("app.timeinterval=10<p>");
+			logger.info("app.timeinterval=10<p>");
 			jobParams.put("app.timeinterval", "10");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			JobExecution execution1 = jobOp.startJobAndWaitForResult("StepContextTestBatchlet", jobParams);
 		
 			List<StepExecution> steps = jobOp.getStepExecutions(execution1.getExecutionId());
@@ -124,10 +108,10 @@ public class ContextAndListenerTests {
 			assertWithMessage("list of step executions == 1", steps.size() == 1);
 			
 			String testString = "StepName=step1;StepExecutionId=" + steps.get(0).getStepExecutionId();
-			Reporter.log("EXPECTED JobExecution getBatchStatus()=COMPLETED<p>");
-			Reporter.log("ACTUAL JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
-			Reporter.log("EXPECTED JobExecution getExitStatus()="+testString+"<p>");
-			Reporter.log("ACTUAL JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
+			logger.info("EXPECTED JobExecution getBatchStatus()=COMPLETED<p>");
+			logger.info("ACTUAL JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
+			logger.info("EXPECTED JobExecution getExitStatus()="+testString+"<p>");
+			logger.info("ACTUAL JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
 			assertWithMessage("Testing batch status", BatchStatus.COMPLETED, execution1.getBatchStatus());
 			assertWithMessage("Testing exit status", testString, execution1.getExitStatus());
 			
@@ -142,7 +126,7 @@ public class ContextAndListenerTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test 
+ 
 	public void testOneArtifactIsJobAndStepListener() throws Exception {
 
 		String METHOD = "testOneArtifactIsJobAndStepListener";
@@ -153,20 +137,20 @@ public class ContextAndListenerTests {
 					"BeforeStep" + "UnusedExitStatusForPartitions" + "AfterStep" + 
 					"AfterJob";
 
-			Reporter.log("Locate job XML file: oneArtifactIsJobAndStepListener.xml<p>");
+			logger.info("Locate job XML file: oneArtifactIsJobAndStepListener.xml<p>");
 
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
-			Reporter.log("app.timeinterval=10<p>");
+			logger.info("app.timeinterval=10<p>");
 			jobParams.put("app.timeinterval", "10");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			JobExecution execution1 = jobOp.startJobAndWaitForResult("oneArtifactIsJobAndStepListener", jobParams);
 
-			Reporter.log("EXPECTED JobExecution getBatchStatus()=COMPLETED<p>");
-			Reporter.log("ACTUAL JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
-			Reporter.log("EXPECTED JobExecution getExitStatus()="+expectedStr+"<p>");
-			Reporter.log("ACTUAL JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
+			logger.info("EXPECTED JobExecution getBatchStatus()=COMPLETED<p>");
+			logger.info("ACTUAL JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
+			logger.info("EXPECTED JobExecution getExitStatus()="+expectedStr+"<p>");
+			logger.info("ACTUAL JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
 			assertWithMessage("Testing batch status", BatchStatus.COMPLETED, execution1.getBatchStatus());
 			assertWithMessage("Testing exit status", expectedStr, execution1.getExitStatus());
 		} catch (Exception e) {
@@ -180,7 +164,7 @@ public class ContextAndListenerTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test 
+ 
 	public void testgetException() throws Exception {
 
 		String METHOD = "testgetException";
@@ -188,19 +172,19 @@ public class ContextAndListenerTests {
 		try {
 			String expectedStr = "MyChunkListener: found instanceof MyParentException";
 
-			Reporter.log("Locate job XML file: job_chunk_getException.xml<p>");
+			logger.info("Locate job XML file: job_chunk_getException.xml<p>");
 
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
-			Reporter.log("fail.immediate=true<p>");
+			logger.info("fail.immediate=true<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			JobExecution execution1 = jobOp.startJobAndWaitForResult("job_chunk_getException", jobParams);
 
-			Reporter.log("EXPECTED JobExecution getBatchStatus()=FAILED<p>");
-			Reporter.log("ACTUAL JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
-			Reporter.log("EXPECTED JobExecution getExitStatus()="+expectedStr+"<p>");
-			Reporter.log("ACTUAL JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
+			logger.info("EXPECTED JobExecution getBatchStatus()=FAILED<p>");
+			logger.info("ACTUAL JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
+			logger.info("EXPECTED JobExecution getExitStatus()="+expectedStr+"<p>");
+			logger.info("ACTUAL JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
 			assertWithMessage("Testing batch status", BatchStatus.FAILED, execution1.getBatchStatus());
 			assertWithMessage("Testing exit status", expectedStr, execution1.getExitStatus());
 		} catch (Exception e) {
@@ -214,7 +198,7 @@ public class ContextAndListenerTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test 
+ 
 	public void testgetExceptionListenerBased() throws Exception {
 
 		String METHOD = "testgetExceptionListenerBased";
@@ -222,19 +206,19 @@ public class ContextAndListenerTests {
 		try {
 			String expectedStr = "MyChunkListener: found instanceof MyParentException";
 
-			Reporter.log("Locate job XML file: job_chunk_getExceptionListeners.xml<p>");
+			logger.info("Locate job XML file: job_chunk_getExceptionListeners.xml<p>");
 
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
-			Reporter.log("fail.immediate=true<p>");
+			logger.info("fail.immediate=true<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			JobExecution execution1 = jobOp.startJobAndWaitForResult("job_chunk_getExceptionListeners", jobParams);
 
-			Reporter.log("EXPECTED JobExecution getBatchStatus()=FAILED<p>");
-			Reporter.log("ACTUAL JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
-			Reporter.log("EXPECTED JobExecution getExitStatus()="+expectedStr+"<p>");
-			Reporter.log("ACTUAL JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
+			logger.info("EXPECTED JobExecution getBatchStatus()=FAILED<p>");
+			logger.info("ACTUAL JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
+			logger.info("EXPECTED JobExecution getExitStatus()="+expectedStr+"<p>");
+			logger.info("ACTUAL JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
 			assertWithMessage("Testing batch status", BatchStatus.FAILED, execution1.getBatchStatus());
 			assertWithMessage("Testing exit status", expectedStr, execution1.getExitStatus());
 		} catch (Exception e) {
@@ -250,19 +234,19 @@ public class ContextAndListenerTests {
      * @test_Strategy: FIXME
      */
     @Test
-    @org.junit.Test 
+ 
     public void testJobContextIsUniqueForMainThreadAndPartitions() throws Exception {
 
         String METHOD = "testJobContextIsUniqueForMainThreadAndPartitions";
         begin(METHOD);
 
         try {
-            Reporter.log("Locate job XML file: job_partitioned_1step.xml<p>");
+            logger.info("Locate job XML file: job_partitioned_1step.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult<p>");
+            logger.info("Invoke startJobAndWaitForResult<p>");
             JobExecution jobExecution = jobOp.startJobAndWaitForResult("job_partitioned_1step");
 
-            Reporter.log("JobExecution getBatchStatus()="+jobExecution.getBatchStatus()+"<p>");
+            logger.info("JobExecution getBatchStatus()="+jobExecution.getBatchStatus()+"<p>");
             assertObjEquals(BatchStatus.COMPLETED, jobExecution.getBatchStatus());
             assertObjEquals("COMPLETED", jobExecution.getExitStatus());
             
@@ -279,19 +263,19 @@ public class ContextAndListenerTests {
      * @test_Strategy: FIXME
      */
     @Test
-    @org.junit.Test 
+ 
     public void testJobContextIsUniqueForMainThreadAndFlowsInSplits() throws Exception {
 
         String METHOD = "testJobContextIsUniqueForMainThreadAndFlowsInSplits";
         begin(METHOD);
 
         try {
-            Reporter.log("Locate job XML file: job_split_batchlet_4steps.xml<p>");
+            logger.info("Locate job XML file: job_split_batchlet_4steps.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult<p>");
+            logger.info("Invoke startJobAndWaitForResult<p>");
             JobExecution execution = jobOp.startJobAndWaitForResult("job_split_batchlet_4steps");
 
-            Reporter.log("JobExecution getBatchStatus()="+execution.getBatchStatus()+"<p>");
+            logger.info("JobExecution getBatchStatus()="+execution.getBatchStatus()+"<p>");
             assertObjEquals(BatchStatus.COMPLETED, execution.getBatchStatus());
             assertObjEquals("COMPLETED", execution.getExitStatus());
             
@@ -308,18 +292,18 @@ public class ContextAndListenerTests {
      * @test_Strategy: FIXME
      */
     @Test
-    @org.junit.Test
+
     public void testStepContextIsUniqueForMainThreadAndPartitions() throws Exception {
         String METHOD = "testStepContextIsUniqueForMainThreadAndPartitions";
         begin(METHOD);
 
         try {
-            Reporter.log("Locate job XML file: job_partitioned_1step.xml<p>");
+            logger.info("Locate job XML file: job_partitioned_1step.xml<p>");
 
-            Reporter.log("Invoke startJobAndWaitForResult<p>");
+            logger.info("Invoke startJobAndWaitForResult<p>");
             JobExecution jobExecution = jobOp.startJobAndWaitForResult("job_partitioned_1step");
 
-            Reporter.log("JobExecution getBatchStatus()=" + jobExecution.getBatchStatus() + "<p>");
+            logger.info("JobExecution getBatchStatus()=" + jobExecution.getBatchStatus() + "<p>");
             
             assertObjEquals(BatchStatus.COMPLETED, jobExecution.getBatchStatus());
             
@@ -336,17 +320,17 @@ public class ContextAndListenerTests {
         }
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanup() throws Exception {
     }
 
     private static void handleException(String methodName, Exception e) throws Exception {
-		Reporter.log("Caught exception: " + e.getMessage()+"<p>");
-		Reporter.log(methodName + " failed<p>");
+		logger.info("Caught exception: " + e.getMessage()+"<p>");
+		logger.info(methodName + " failed<p>");
 		throw e;
 	}
 
     private void begin(String str) {
-        Reporter.log("Begin test method: " + str + "<p>");
+        logger.info("Begin test method: " + str + "<p>");
     }
 }

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ContextsGetIdTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ContextsGetIdTests.java
@@ -25,16 +25,13 @@ import java.util.Properties;
 import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.JobExecution;
 
-import org.junit.Before;
-import org.testng.Reporter;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
-
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.*;
 
 public class ContextsGetIdTests {
 
+	private static final Logger logger = Logger.getLogger(ContextsGetIdTests.class.getName());
 	private JobOperatorBridge jobOp = null;
 
 	/**
@@ -54,7 +51,7 @@ public class ContextsGetIdTests {
 	 * @throws Exception
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testJobContextGetId() throws Exception {
 
 		String METHOD = "testJobContextGetId";
@@ -63,13 +60,13 @@ public class ContextsGetIdTests {
 
 			String jobId = "job1";
 
-			Reporter.log("starting job");
+			logger.info("starting job");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("contexts_getid_jobcontext", null);
-			Reporter.log("Job Status = " + jobExec.getBatchStatus());
+			logger.info("Job Status = " + jobExec.getBatchStatus());
 
 			assertWithMessage("job id equals job1", jobId, jobExec.getExitStatus());
 			assertWithMessage("Job completed", BatchStatus.COMPLETED, jobExec.getBatchStatus());
-			Reporter.log("job completed");
+			logger.info("job completed");
 		} catch (Exception e) {
 			handleException(METHOD, e);
 		}
@@ -92,7 +89,7 @@ public class ContextsGetIdTests {
 	 * @throws Exception
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testStepContextGetId() throws Exception {
 
 		String METHOD = "testStepContextGetId";
@@ -100,22 +97,22 @@ public class ContextsGetIdTests {
 		try {
 			String stepId = "step1";
 
-			Reporter.log("starting job");
+			logger.info("starting job");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("contexts_getid_stepcontext", null);
-			Reporter.log("Job Status = " + jobExec.getBatchStatus());
+			logger.info("Job Status = " + jobExec.getBatchStatus());
 
 			assertWithMessage("job id equals job1", stepId, jobExec.getExitStatus());
 
 			assertWithMessage("Job completed", BatchStatus.COMPLETED, jobExec.getBatchStatus());
-			Reporter.log("job completed");
+			logger.info("job completed");
 		} catch (Exception e) {
 			handleException(METHOD, e);
 		}
 	}
 
 	private static void handleException(String methodName, Exception e) throws Exception {
-		Reporter.log("Caught exception: " + e.getMessage()+"<p>");
-		Reporter.log(methodName + " failed<p>");
+		logger.info("Caught exception: " + e.getMessage()+"<p>");
+		logger.info(methodName + " failed<p>");
 		throw e;
 	}
 
@@ -136,13 +133,12 @@ public class ContextsGetIdTests {
 
 	}
 
-	@BeforeTest
-	@Before
+	@BeforeEach
 	public void beforeTest() throws ClassNotFoundException {
 		jobOp = new JobOperatorBridge(); 
 	}
 
-	@AfterTest
+	@AfterEach
 	public void afterTest() {
 		jobOp = null;
 	}

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/DeciderTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/DeciderTests.java
@@ -28,36 +28,20 @@ import javax.batch.operations.JobStartException;
 import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.JobExecution;
 
-import org.junit.BeforeClass;
-import org.testng.Reporter;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
 import com.ibm.jbatch.tck.artifacts.common.StatusConstants;
 import com.ibm.jbatch.tck.artifacts.specialized.DeciderTestsBatchlet;
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import org.junit.jupiter.api.*;
 
 public class DeciderTests implements StatusConstants {
 	private final static Logger logger = Logger.getLogger(DeciderTests.class.getName());
-	private static JobOperatorBridge jobOp = null;
+	private JobOperatorBridge jobOp = null;
 
 	private final static String FORCE_STOP_EXITSTATUS = "STEP_COMPLETE_BUT_FORCE_JOB_STOPPED_STATUS";
 	private final static String FORCE_FAIL_EXITSTATUS = "STEP_COMPLETE_BUT_FORCE_JOB_FAILED_STATUS";
 
-
-	public static void setup(String[] args, Properties props) throws Exception {
-		String METHOD = "setup";
-
-		try {
-			jobOp = new JobOperatorBridge();
-		} catch (Exception e) {
-			handleException(METHOD, e);
-		}
-	}
-
-	@BeforeMethod
-	@BeforeClass
-	public static void setUp() throws Exception {
+	@BeforeEach
+	public void setUp() throws Exception {
 		jobOp = new JobOperatorBridge();                              
 	}
 
@@ -95,7 +79,7 @@ public class DeciderTests implements StatusConstants {
 	 *                    
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testDeciderEndNormal() throws Exception {
 
 		String METHOD = "testDeciderEndNormal";
@@ -103,30 +87,30 @@ public class DeciderTests implements StatusConstants {
 		try {
 			// 1. Here "EndSpecial" is the exit status the decider will return if the step exit status
 			// is the "special" exit status value.  It is set as a property on the decider.
-			Reporter.log("Build job parameters for EndSpecial exit status<p>");
+			logger.info("Build job parameters for EndSpecial exit status<p>");
 
 			Properties jobParameters = new Properties();
 
 			// 2. Here "EndNormal" is the exit status the decider will return if the step exit status
 			// is the "normal" exit status value.  It is set as a property on the batchlet and passed
 			// along to the decider via stepContext.setTransientUserData().
-			Reporter.log("Set job parameters property " + DeciderTestsBatchlet.ACTION + " with value EndNormal<p>");
+			logger.info("Set job parameters property " + DeciderTestsBatchlet.ACTION + " with value EndNormal<p>");
 			jobParameters.setProperty(DeciderTestsBatchlet.ACTION, "EndNormal");
 			// 3. This "ACTUAL_VALUE" is a property set on the batchlet.  It will either indicate to end
 			// the step with a "normal" or "special" exit status.            
-			Reporter.log("Set job parameters property " + DeciderTestsBatchlet.ACTUAL_VALUE + " with value " + DeciderTestsBatchlet.NORMAL_VALUE + "<p>");
+			logger.info("Set job parameters property " + DeciderTestsBatchlet.ACTUAL_VALUE + " with value " + DeciderTestsBatchlet.NORMAL_VALUE + "<p>");
 			jobParameters.setProperty(DeciderTestsBatchlet.ACTUAL_VALUE, DeciderTestsBatchlet.NORMAL_VALUE);
 
-			Reporter.log("Set job parameters property " + DeciderTestsBatchlet.SPECIAL_EXIT_STATUS + " with value EndSpecial<p>");
+			logger.info("Set job parameters property " + DeciderTestsBatchlet.SPECIAL_EXIT_STATUS + " with value EndSpecial<p>");
 			jobParameters.setProperty(DeciderTestsBatchlet.SPECIAL_EXIT_STATUS, "EndSpecial");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_decider_incompleterun", jobParameters); 
 
-			Reporter.log("Expected JobExecution getExitStatus()=EndNormal<p>");
-			Reporter.log("Actual JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
-			Reporter.log("Expected JobExecution getStatus()=COMPLETED<p>");
-			Reporter.log("Actual JobExecution getStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("Expected JobExecution getExitStatus()=EndNormal<p>");
+			logger.info("Actual JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
+			logger.info("Expected JobExecution getStatus()=COMPLETED<p>");
+			logger.info("Actual JobExecution getStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals("EndNormal", jobExec.getExitStatus());
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 		} catch(Exception e) {
@@ -141,30 +125,30 @@ public class DeciderTests implements StatusConstants {
 	 * @test_Strategy: see testDeciderEndNormal
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testDeciderEndSpecial() throws Exception {
 		String METHOD = "testDeciderEndSpecial";
 
 		try {
-			Reporter.log("Build job parameters for EndSpecial exit status<p>");	    
+			logger.info("Build job parameters for EndSpecial exit status<p>");	    
 
 			Properties jobParameters = new Properties();        
 			jobParameters.setProperty(DeciderTestsBatchlet.ACTION, "EndNormal");
-			Reporter.log("Set job parameters property " + DeciderTestsBatchlet.ACTION + " with value EndNormal<p>");
+			logger.info("Set job parameters property " + DeciderTestsBatchlet.ACTION + " with value EndNormal<p>");
 			// 1. This is the only test parameter that differs from testDeciderEndNormal().
-			Reporter.log("Set job parameters property " + DeciderTestsBatchlet.ACTUAL_VALUE + " with value " + DeciderTestsBatchlet.SPECIAL_VALUE +"<p>");
+			logger.info("Set job parameters property " + DeciderTestsBatchlet.ACTUAL_VALUE + " with value " + DeciderTestsBatchlet.SPECIAL_VALUE +"<p>");
 			jobParameters.setProperty(DeciderTestsBatchlet.ACTUAL_VALUE, DeciderTestsBatchlet.SPECIAL_VALUE);
-			Reporter.log("Set job parameters property " + DeciderTestsBatchlet.SPECIAL_EXIT_STATUS + " with value EndSpecial<p>");
+			logger.info("Set job parameters property " + DeciderTestsBatchlet.SPECIAL_EXIT_STATUS + " with value EndSpecial<p>");
 			jobParameters.setProperty(DeciderTestsBatchlet.SPECIAL_EXIT_STATUS, "EndSpecial");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_decider_incompleterun", jobParameters); 
 
 			// 2. And the job exit status differs accordingly.
-			Reporter.log("Expected JobExecution getExitStatus()=EndSpecial<p>");
-			Reporter.log("Actual JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
-			Reporter.log("Expected JobExecution getBatchStatus()=COMPLETED<p>");
-			Reporter.log("Actual JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("Expected JobExecution getExitStatus()=EndSpecial<p>");
+			logger.info("Actual JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
+			logger.info("Expected JobExecution getBatchStatus()=COMPLETED<p>");
+			logger.info("Actual JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals("EndSpecial", jobExec.getExitStatus());
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 		} catch(Exception e) {
@@ -179,30 +163,30 @@ public class DeciderTests implements StatusConstants {
 	 * @test_Strategy: see testDeciderEndNormal
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testDeciderStopNormal() throws Exception {
 		String METHOD = " testDeciderStopNormal";
 
 		try {
-			Reporter.log("Build job parameters for StopSpecial exit status<p>");
+			logger.info("Build job parameters for StopSpecial exit status<p>");
 
 			Properties jobParameters = new Properties();    
-			Reporter.log("Set job parameters property " + DeciderTestsBatchlet.ACTION + " with value StopNormal<p>");
+			logger.info("Set job parameters property " + DeciderTestsBatchlet.ACTION + " with value StopNormal<p>");
 			jobParameters.setProperty(DeciderTestsBatchlet.ACTION, "StopNormal");
 
-			Reporter.log("Set job parameters property " + DeciderTestsBatchlet.ACTUAL_VALUE + " with value " + DeciderTestsBatchlet.NORMAL_VALUE +"<p>");
+			logger.info("Set job parameters property " + DeciderTestsBatchlet.ACTUAL_VALUE + " with value " + DeciderTestsBatchlet.NORMAL_VALUE +"<p>");
 			jobParameters.setProperty(DeciderTestsBatchlet.ACTUAL_VALUE, DeciderTestsBatchlet.NORMAL_VALUE);
 
-			Reporter.log("Set job parameters property " + DeciderTestsBatchlet.SPECIAL_EXIT_STATUS + " with value StopSpecial<p>");
+			logger.info("Set job parameters property " + DeciderTestsBatchlet.SPECIAL_EXIT_STATUS + " with value StopSpecial<p>");
 			jobParameters.setProperty(DeciderTestsBatchlet.SPECIAL_EXIT_STATUS, "StopSpecial");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_decider_incompleterun", jobParameters); 
 
-			Reporter.log("Expected JobExecution getExitStatus()=StopNormal<p>");
-			Reporter.log("Actual JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
-			Reporter.log("Expected JobExecution getBatchStatus()=STOPPED<p>");
-			Reporter.log("Actual JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("Expected JobExecution getExitStatus()=StopNormal<p>");
+			logger.info("Actual JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
+			logger.info("Expected JobExecution getBatchStatus()=STOPPED<p>");
+			logger.info("Actual JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals("StopNormal", jobExec.getExitStatus());
 			assertObjEquals(BatchStatus.STOPPED, jobExec.getBatchStatus());
 		} catch(Exception e) {
@@ -218,30 +202,30 @@ public class DeciderTests implements StatusConstants {
 	 * @test_Strategy: see testDeciderEndNormal
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testDeciderStopSpecial() throws Exception {
 		String METHOD = "testDeciderStopSpecial";
 
 		try {
-			Reporter.log("Build job parameters for StopSpecial exit status<p>");
+			logger.info("Build job parameters for StopSpecial exit status<p>");
 
 			Properties jobParameters = new Properties();     
-			Reporter.log("Set job parameters property " + DeciderTestsBatchlet.ACTION + " with value StopNormal<p>");
+			logger.info("Set job parameters property " + DeciderTestsBatchlet.ACTION + " with value StopNormal<p>");
 			jobParameters.setProperty(DeciderTestsBatchlet.ACTION, "StopNormal");
 
-			Reporter.log("Set job parameters property " + DeciderTestsBatchlet.ACTUAL_VALUE + " with value " + DeciderTestsBatchlet.SPECIAL_VALUE +"<p>");
+			logger.info("Set job parameters property " + DeciderTestsBatchlet.ACTUAL_VALUE + " with value " + DeciderTestsBatchlet.SPECIAL_VALUE +"<p>");
 			jobParameters.setProperty(DeciderTestsBatchlet.ACTUAL_VALUE, DeciderTestsBatchlet.SPECIAL_VALUE);
 
-			Reporter.log("Set job parameters property " + DeciderTestsBatchlet.SPECIAL_EXIT_STATUS + " with value StopSpecial<p>");
+			logger.info("Set job parameters property " + DeciderTestsBatchlet.SPECIAL_EXIT_STATUS + " with value StopSpecial<p>");
 			jobParameters.setProperty(DeciderTestsBatchlet.SPECIAL_EXIT_STATUS, "StopSpecial");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_decider_incompleterun", jobParameters); 
 
-			Reporter.log("Expected JobExecution getExitStatus()=StopSpecial<p>");
-			Reporter.log("Actual JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
-			Reporter.log("Expected JobExecution getBatchStatus()=STOPPED<p>");
-			Reporter.log("Actual JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("Expected JobExecution getExitStatus()=StopSpecial<p>");
+			logger.info("Actual JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
+			logger.info("Expected JobExecution getBatchStatus()=STOPPED<p>");
+			logger.info("Actual JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals("StopSpecial", jobExec.getExitStatus());
 			assertObjEquals(BatchStatus.STOPPED, jobExec.getBatchStatus());
 		} catch(Exception e) {
@@ -256,31 +240,31 @@ public class DeciderTests implements StatusConstants {
 	 * @test_Strategy: see testDeciderEndNormal
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testDeciderFailNormal() throws Exception {
 
 		String METHOD = "testDeciderFailNormal";
 
 		try {
-			Reporter.log("Build job parameters for FailSpecial exit status<p>");	    	
+			logger.info("Build job parameters for FailSpecial exit status<p>");	    	
 
 			Properties jobParameters = new Properties();        
-			Reporter.log("Set job parameters property " + DeciderTestsBatchlet.ACTION + " with value FailNormal<p>");
+			logger.info("Set job parameters property " + DeciderTestsBatchlet.ACTION + " with value FailNormal<p>");
 			jobParameters.setProperty(DeciderTestsBatchlet.ACTION, "FailNormal");
 
-			Reporter.log("Set job parameters property " + DeciderTestsBatchlet.ACTUAL_VALUE + " with value " + DeciderTestsBatchlet.NORMAL_VALUE +"<p>");
+			logger.info("Set job parameters property " + DeciderTestsBatchlet.ACTUAL_VALUE + " with value " + DeciderTestsBatchlet.NORMAL_VALUE +"<p>");
 			jobParameters.setProperty(DeciderTestsBatchlet.ACTUAL_VALUE, DeciderTestsBatchlet.NORMAL_VALUE);
 
-			Reporter.log("Set job parameters property " + DeciderTestsBatchlet.SPECIAL_EXIT_STATUS + " with value FailSpecial<p>");
+			logger.info("Set job parameters property " + DeciderTestsBatchlet.SPECIAL_EXIT_STATUS + " with value FailSpecial<p>");
 			jobParameters.setProperty(DeciderTestsBatchlet.SPECIAL_EXIT_STATUS, "FailSpecial");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_decider_incompleterun", jobParameters); 
 
-			Reporter.log("Expected JobExecution getExitStatus()=FailNormal<p>");
-			Reporter.log("Actual JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
-			Reporter.log("Expected JobExecution getBatchStatus()=FAILED<p>");
-			Reporter.log("Actual JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("Expected JobExecution getExitStatus()=FailNormal<p>");
+			logger.info("Actual JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
+			logger.info("Expected JobExecution getBatchStatus()=FAILED<p>");
+			logger.info("Actual JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals("FailNormal", jobExec.getExitStatus());
 			assertObjEquals(BatchStatus.FAILED, jobExec.getBatchStatus());
 		} catch(Exception e) {
@@ -295,30 +279,30 @@ public class DeciderTests implements StatusConstants {
 	 * @test_Strategy: see testDeciderEndNormal
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testDeciderFailSpecial() throws Exception {
 		String METHOD = "testDeciderFailSpecial";
 
 		try {
-			Reporter.log("Build job parameters for FailSpecial exit status<p>");
+			logger.info("Build job parameters for FailSpecial exit status<p>");
 
 			Properties jobParameters = new Properties();        
-			Reporter.log("Set job parameters property " + DeciderTestsBatchlet.ACTION + " with value FailNormal<p>");
+			logger.info("Set job parameters property " + DeciderTestsBatchlet.ACTION + " with value FailNormal<p>");
 			jobParameters.setProperty(DeciderTestsBatchlet.ACTION, "FailNormal");
 
-			Reporter.log("Set job parameters property " + DeciderTestsBatchlet.ACTUAL_VALUE + " with value " + DeciderTestsBatchlet.SPECIAL_VALUE +"<p>");
+			logger.info("Set job parameters property " + DeciderTestsBatchlet.ACTUAL_VALUE + " with value " + DeciderTestsBatchlet.SPECIAL_VALUE +"<p>");
 			jobParameters.setProperty(DeciderTestsBatchlet.ACTUAL_VALUE, DeciderTestsBatchlet.SPECIAL_VALUE);
 
-			Reporter.log("Set job parameters property " + DeciderTestsBatchlet.SPECIAL_EXIT_STATUS + " with value FailSpecial<p>");
+			logger.info("Set job parameters property " + DeciderTestsBatchlet.SPECIAL_EXIT_STATUS + " with value FailSpecial<p>");
 			jobParameters.setProperty(DeciderTestsBatchlet.SPECIAL_EXIT_STATUS, "FailSpecial");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_decider_incompleterun", jobParameters); 
 
-			Reporter.log("Expected JobExecution getExitStatus()=FailSpecial<p>");
-			Reporter.log("Actual JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
-			Reporter.log("Expected JobExecution getBatchStatus()=FAILED<p>");
-			Reporter.log("Actual JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("Expected JobExecution getExitStatus()=FailSpecial<p>");
+			logger.info("Actual JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
+			logger.info("Expected JobExecution getBatchStatus()=FAILED<p>");
+			logger.info("Actual JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals("FailSpecial", jobExec.getExitStatus());
 			assertObjEquals(BatchStatus.FAILED, jobExec.getBatchStatus());
 		} catch(Exception e) {
@@ -332,32 +316,32 @@ public class DeciderTests implements StatusConstants {
 	 * @test_Strategy: see testDeciderEndNormal
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testDeciderNextNormal() throws Exception {
 		String METHOD = "testDeciderNextNormal";
 
 		try {
-			Reporter.log("Build job parameters for NextSpecial exit status<p>");
+			logger.info("Build job parameters for NextSpecial exit status<p>");
 
 			Properties jobParameters = new Properties();        
-			Reporter.log("Set job parameters property " + DeciderTestsBatchlet.ACTION + " with value NextNormal<p>");
+			logger.info("Set job parameters property " + DeciderTestsBatchlet.ACTION + " with value NextNormal<p>");
 			jobParameters.setProperty(DeciderTestsBatchlet.ACTION, "NextNormal");
 
-			Reporter.log("Set job parameters property " + DeciderTestsBatchlet.ACTUAL_VALUE + " with value " + DeciderTestsBatchlet.NORMAL_VALUE +"<p>");
+			logger.info("Set job parameters property " + DeciderTestsBatchlet.ACTUAL_VALUE + " with value " + DeciderTestsBatchlet.NORMAL_VALUE +"<p>");
 			jobParameters.setProperty(DeciderTestsBatchlet.ACTUAL_VALUE, DeciderTestsBatchlet.NORMAL_VALUE);
 
-			Reporter.log("Set job parameters property " + DeciderTestsBatchlet.SPECIAL_EXIT_STATUS + " with value NextSpecial<p>");
+			logger.info("Set job parameters property " + DeciderTestsBatchlet.SPECIAL_EXIT_STATUS + " with value NextSpecial<p>");
 			jobParameters.setProperty(DeciderTestsBatchlet.SPECIAL_EXIT_STATUS, "NextSpecial");
 
-			Reporter.log("Create single job listener deciderTestJobListener and get JSL<p>");
+			logger.info("Create single job listener deciderTestJobListener and get JSL<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_decider_completerun", jobParameters); 
 
-			Reporter.log("Expected JobExecution getExitStatus()="+GOOD_JOB_EXIT_STATUS+"<p>");
-			Reporter.log("Actual JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
-			Reporter.log("Expected JobExecution getBatchStatus()=COMPLETED<p>");
-			Reporter.log("Actual JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("Expected JobExecution getExitStatus()="+GOOD_JOB_EXIT_STATUS+"<p>");
+			logger.info("Actual JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
+			logger.info("Expected JobExecution getBatchStatus()=COMPLETED<p>");
+			logger.info("Actual JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(GOOD_JOB_EXIT_STATUS, jobExec.getExitStatus());
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 		} catch(Exception e) {
@@ -371,34 +355,34 @@ public class DeciderTests implements StatusConstants {
 	 * @test_Strategy: see testDeciderEndNormal
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testDeciderNextSpecial() throws Exception {
 		String METHOD = "testDeciderNextSpecial";
 
 		try {
-			Reporter.log("Build job parameters for NextSpecial exit status<p>");	
+			logger.info("Build job parameters for NextSpecial exit status<p>");	
 
 			Properties jobParameters = new Properties();        
 
-			Reporter.log("Set job parameters property " + DeciderTestsBatchlet.ACTION + " with value NextNormal<p>");
+			logger.info("Set job parameters property " + DeciderTestsBatchlet.ACTION + " with value NextNormal<p>");
 			jobParameters.setProperty(DeciderTestsBatchlet.ACTION, "NextNormal");
 
-			Reporter.log("Set job parameters property " + DeciderTestsBatchlet.ACTUAL_VALUE + " with value " + DeciderTestsBatchlet.SPECIAL_VALUE + "<p>");
+			logger.info("Set job parameters property " + DeciderTestsBatchlet.ACTUAL_VALUE + " with value " + DeciderTestsBatchlet.SPECIAL_VALUE + "<p>");
 			jobParameters.setProperty(DeciderTestsBatchlet.ACTUAL_VALUE, DeciderTestsBatchlet.SPECIAL_VALUE);
 
-			Reporter.log("Set job parameters property " + DeciderTestsBatchlet.SPECIAL_EXIT_STATUS + " with value NextSpecial<p>");
+			logger.info("Set job parameters property " + DeciderTestsBatchlet.SPECIAL_EXIT_STATUS + " with value NextSpecial<p>");
 			jobParameters.setProperty(DeciderTestsBatchlet.SPECIAL_EXIT_STATUS, "NextSpecial");
 
-			Reporter.log("Create single job listener deciderTestJobListener and get JSL<p>");
+			logger.info("Create single job listener deciderTestJobListener and get JSL<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_decider_completerun", jobParameters); 
 
 			// This actually exits with the exact same status as the "...NextNormal" test.
-			Reporter.log("Expected JobExecution getExitStatus()="+GOOD_JOB_EXIT_STATUS+"<p>");
-			Reporter.log("Actual JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
-			Reporter.log("Expected JobExecution getBatchStatus()=COMPLETED<p>");
-			Reporter.log("Actual JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("Expected JobExecution getExitStatus()="+GOOD_JOB_EXIT_STATUS+"<p>");
+			logger.info("Actual JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
+			logger.info("Expected JobExecution getBatchStatus()=COMPLETED<p>");
+			logger.info("Actual JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(GOOD_JOB_EXIT_STATUS, jobExec.getExitStatus());
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 		} catch(Exception e) {
@@ -414,13 +398,13 @@ public class DeciderTests implements StatusConstants {
 	 *   confirm that the exit status is set on the JobContext directly, but this is the intent behind the test method name.
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testDeciderExitStatusIsSetOnJobContext() throws Exception {
 
 		String METHOD = "testDeciderExitStatusIsSetOnJobContext";
 
 		try {
-			Reporter.log("Build job parameters.<p>");    
+			logger.info("Build job parameters.<p>");    
 
 			Properties jobParameters = new Properties();
 			jobParameters.setProperty("step.complete.but.force.job.stopped.status", FORCE_STOP_EXITSTATUS);
@@ -432,7 +416,7 @@ public class DeciderTests implements StatusConstants {
 			jobParameters.setProperty("fail.job.after.this.step", "step1");
 
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("decider_transitions_on_restart", jobParameters); 
 
 			assertObjEquals(BatchStatus.FAILED, jobExec.getBatchStatus());
@@ -451,7 +435,7 @@ public class DeciderTests implements StatusConstants {
 	 *  or BatchStatus of FAILED.
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testDeciderCannotbeFirstElementOnStart() throws Exception {
 
 		String METHOD = "testDeciderCannotbeFirstElementOnStart";
@@ -462,7 +446,7 @@ public class DeciderTests implements StatusConstants {
 			try {
 				jobExec = jobOp.startJobAndWaitForResult("decider_as_first_job_element_fails"); 
 			} catch (JobStartException e) {
-				Reporter.log("Caught JobStartException:  " + e.getLocalizedMessage());
+				logger.info("Caught JobStartException:  " + e.getLocalizedMessage());
 				seenException = true;
 			}
 
@@ -471,7 +455,7 @@ public class DeciderTests implements StatusConstants {
 
 			// If we didn't catch an exception that we require that the implementation fail the job execution.
 			if (!seenException) {
-				Reporter.log("Didn't catch JobStartException, Job Batch Status = " + jobExec.getBatchStatus());
+				logger.info("Didn't catch JobStartException, Job Batch Status = " + jobExec.getBatchStatus());
 				assertWithMessage("Job should have failed because of decision as first execution element.", BatchStatus.FAILED, jobExec.getBatchStatus());
 			}
 		} catch(Exception e) {
@@ -494,12 +478,12 @@ public class DeciderTests implements StatusConstants {
 	 *                     been performed.
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testDeciderTransitionFromStepAndAllowRestart() throws Exception {
 		String METHOD = "testDeciderTransitionFromStepAndAllowRestart";
 
 		try {
-			Reporter.log("Build job parameters.<p>");    
+			logger.info("Build job parameters.<p>");    
 
 			Properties jobParameters = new Properties();
 			jobParameters.setProperty("step.complete.but.force.job.stopped.status", FORCE_STOP_EXITSTATUS);
@@ -511,7 +495,7 @@ public class DeciderTests implements StatusConstants {
 			jobParameters.setProperty("fail.job.after.this.step", "None");
 
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("decider_transitions_on_restart", jobParameters); 
 
 			assertObjEquals(BatchStatus.STOPPED, jobExec.getBatchStatus());
@@ -520,7 +504,7 @@ public class DeciderTests implements StatusConstants {
 			Properties restartJobParameters = new Properties(jobParameters);
 			restartJobParameters.setProperty("stop.job.after.this.step", "None");
 
-			Reporter.log("Invoke restartJobAndWaitForResult<p>");
+			logger.info("Invoke restartJobAndWaitForResult<p>");
 			JobExecution jobExec2 = jobOp.restartJobAndWaitForResult(jobExec.getExecutionId(), restartJobParameters);
 
 			assertObjEquals("3:flow1step2_CONTINUE", jobExec2.getExitStatus());
@@ -549,13 +533,13 @@ public class DeciderTests implements StatusConstants {
 	 *                  3. A decision within a flow is configured to stop (based on exit status matching against a <stop> element).
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testDeciderTransitionFromStepWithinFlowAndAllowRestart() throws Exception {
 
 		String METHOD = "testDeciderTransitionFromStepWithinFlowAndAllowRestart";
 
 		try {
-			Reporter.log("Build job parameters.<p>");    
+			logger.info("Build job parameters.<p>");    
 
 			Properties jobParameters = new Properties();
 			jobParameters.setProperty("step.complete.but.force.job.stopped.status", FORCE_STOP_EXITSTATUS);
@@ -566,7 +550,7 @@ public class DeciderTests implements StatusConstants {
 			jobParameters.setProperty("stop.job.after.this.step", "flow1step1");
 			jobParameters.setProperty("fail.job.after.this.step", "None");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("decider_transitions_on_restart", jobParameters); 
 
 			assertObjEquals(BatchStatus.STOPPED, jobExec.getBatchStatus());
@@ -575,7 +559,7 @@ public class DeciderTests implements StatusConstants {
 			Properties restartJobParameters = new Properties(jobParameters);
 			restartJobParameters.setProperty("stop.job.after.this.step", "None");
 
-			Reporter.log("Invoke restartJobAndWaitForResult<p>");
+			logger.info("Invoke restartJobAndWaitForResult<p>");
 			JobExecution jobExec2 = jobOp.restartJobAndWaitForResult(jobExec.getExecutionId(), restartJobParameters);
 
 			assertObjEquals("3:flow1step2_CONTINUE", jobExec2.getExitStatus());
@@ -602,14 +586,14 @@ public class DeciderTests implements StatusConstants {
 	 *                     been performed.
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testDeciderTransitionFromFlowAndAllowRestart() throws Exception {
 
 		String METHOD = "testDeciderTransitionFromFlowAndAllowRestart";
 
 
 		try {
-			Reporter.log("Build job parameters.<p>");    
+			logger.info("Build job parameters.<p>");    
 			Properties jobParameters = new Properties();
 			jobParameters.setProperty("step.complete.but.force.job.stopped.status", FORCE_STOP_EXITSTATUS);
 			jobParameters.setProperty("step.complete.but.force.job.failed.status", FORCE_FAIL_EXITSTATUS);
@@ -619,7 +603,7 @@ public class DeciderTests implements StatusConstants {
 			jobParameters.setProperty("stop.job.after.this.step", "flow1step2");
 			jobParameters.setProperty("fail.job.after.this.step", "None");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("decider_transitions_on_restart", jobParameters); 
 
 			assertObjEquals(BatchStatus.STOPPED, jobExec.getBatchStatus());
@@ -628,7 +612,7 @@ public class DeciderTests implements StatusConstants {
 			Properties restartJobParameters = new Properties(jobParameters);
 			restartJobParameters.setProperty("stop.job.after.this.step", "None");
 
-			Reporter.log("Invoke restartJobAndWaitForResult<p>");
+			logger.info("Invoke restartJobAndWaitForResult<p>");
 			JobExecution jobExec2 = jobOp.restartJobAndWaitForResult(jobExec.getExecutionId(), restartJobParameters);
 
 			assertObjEquals("3:flow1step2_CONTINUE", jobExec2.getExitStatus());
@@ -659,13 +643,13 @@ public class DeciderTests implements StatusConstants {
 	 *                     tightened.  We could go further to assert that the full list of StepExecution(s) is what we'd expect.
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testDeciderTransitionFromSplitAndAllowRestart() throws Exception {
 
 		String METHOD = "testDeciderTransitionFromSplitAndAllowRestart";
 
 		try {
-			Reporter.log("Build job parameters.<p>");    
+			logger.info("Build job parameters.<p>");    
 
 			Properties jobParameters = new Properties();
 			jobParameters.setProperty("step.complete.but.force.job.stopped.status", FORCE_STOP_EXITSTATUS);
@@ -676,7 +660,7 @@ public class DeciderTests implements StatusConstants {
 			jobParameters.setProperty("stop.job.after.this.step", "split1flow1step2");
 			jobParameters.setProperty("stop.job.after.this.step2", "split1flow2step2");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("decider_transitions_from_split_on_restart", jobParameters); 
 
 			assertObjEquals(BatchStatus.STOPPED, jobExec.getBatchStatus());
@@ -686,7 +670,7 @@ public class DeciderTests implements StatusConstants {
 			restartJobParameters.setProperty("stop.job.after.this.step", "None");
 			jobParameters.setProperty("stop.job.after.this.step2", "None");
 
-			Reporter.log("Invoke restartJobAndWaitForResult<p>");
+			logger.info("Invoke restartJobAndWaitForResult<p>");
 			JobExecution jobExec2 = jobOp.restartJobAndWaitForResult(jobExec.getExecutionId(), restartJobParameters);
 
 			assertObjEquals("4:split1flow2step2_CONTINUE", jobExec2.getExitStatus());
@@ -714,13 +698,13 @@ public class DeciderTests implements StatusConstants {
 	 *                  been performed.
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testDeciderTransitionFromStepAndAllowRestartFalse() throws Exception {
 
 		String METHOD = "testDeciderTransitionFromStepAndAllowRestartFalse";
 
 		try {
-			Reporter.log("Build job parameters.<p>");    
+			logger.info("Build job parameters.<p>");    
 
 			Properties jobParameters = new Properties();
 			jobParameters.setProperty("step.complete.but.force.job.stopped.status", FORCE_STOP_EXITSTATUS);
@@ -732,7 +716,7 @@ public class DeciderTests implements StatusConstants {
 			jobParameters.setProperty("fail.job.after.this.step", "None");
 
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("decider_transitions_on_restart", jobParameters); 
 
 			assertObjEquals(BatchStatus.STOPPED, jobExec.getBatchStatus());
@@ -742,7 +726,7 @@ public class DeciderTests implements StatusConstants {
 			restartJobParameters.setProperty("stop.job.after.this.step", "None");
 			restartJobParameters.setProperty("is.restart", "true");
 
-			Reporter.log("Invoke restartJobAndWaitForResult<p>");
+			logger.info("Invoke restartJobAndWaitForResult<p>");
 			JobExecution jobExec2 = jobOp.restartJobAndWaitForResult(jobExec.getExecutionId(), restartJobParameters);
 
 			assertObjEquals("3:flow1step2_CONTINUE", jobExec2.getExitStatus());
@@ -772,13 +756,13 @@ public class DeciderTests implements StatusConstants {
 	 *                  3. A decision within a flow is configured to stop (based on exit status matching against a <stop> element).
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testDeciderTransitionFromStepWithinFlowAndAllowRestartFalse() throws Exception {
 
 		String METHOD = "testDeciderTransitionFromStepWithinFlowAndAllowRestartFalse";
 
 		try {
-			Reporter.log("Build job parameters.<p>");    
+			logger.info("Build job parameters.<p>");    
 
 			Properties jobParameters = new Properties();
 			jobParameters.setProperty("step.complete.but.force.job.stopped.status", FORCE_STOP_EXITSTATUS);
@@ -789,7 +773,7 @@ public class DeciderTests implements StatusConstants {
 			jobParameters.setProperty("stop.job.after.this.step", "flow1step1");
 			jobParameters.setProperty("fail.job.after.this.step", "None");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("decider_transitions_on_restart", jobParameters); 
 
 			assertObjEquals(BatchStatus.STOPPED, jobExec.getBatchStatus());
@@ -799,7 +783,7 @@ public class DeciderTests implements StatusConstants {
 			restartJobParameters.setProperty("stop.job.after.this.step", "None");
 			restartJobParameters.setProperty("is.restart", "true");
 
-			Reporter.log("Invoke restartJobAndWaitForResult<p>");
+			logger.info("Invoke restartJobAndWaitForResult<p>");
 			JobExecution jobExec2 = jobOp.restartJobAndWaitForResult(jobExec.getExecutionId(), restartJobParameters);
 
 			assertObjEquals("3:flow1step2_CONTINUE", jobExec2.getExitStatus());
@@ -829,13 +813,13 @@ public class DeciderTests implements StatusConstants {
 	 *                     been performed.
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testDeciderTransitionFromFlowAndAllowRestartFalse() throws Exception {
 
 		String METHOD = "testDeciderTransitionFromFlowAndAllowRestartFalse";
 
 		try {
-			Reporter.log("Build job parameters.<p>");    
+			logger.info("Build job parameters.<p>");    
 
 			Properties jobParameters = new Properties();
 			jobParameters.setProperty("step.complete.but.force.job.stopped.status", FORCE_STOP_EXITSTATUS);
@@ -846,7 +830,7 @@ public class DeciderTests implements StatusConstants {
 			jobParameters.setProperty("stop.job.after.this.step", "flow1step2");
 			jobParameters.setProperty("fail.job.after.this.step", "None");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("decider_transitions_on_restart", jobParameters); 
 
 			assertObjEquals(BatchStatus.STOPPED, jobExec.getBatchStatus());
@@ -856,7 +840,7 @@ public class DeciderTests implements StatusConstants {
 			restartJobParameters.setProperty("stop.job.after.this.step", "None");
 			restartJobParameters.setProperty("is.restart", "true");
 
-			Reporter.log("Invoke restartJobAndWaitForResult<p>");
+			logger.info("Invoke restartJobAndWaitForResult<p>");
 			JobExecution jobExec2 = jobOp.restartJobAndWaitForResult(jobExec.getExecutionId(), restartJobParameters);
 
 			assertObjEquals("3:flow1step2_CONTINUE", jobExec2.getExitStatus());
@@ -889,13 +873,13 @@ public class DeciderTests implements StatusConstants {
 	 *                     tightened.  We could go further to assert that the full list of StepExecution(s) is what we'd expect.
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testDeciderTransitionFromSplitAndAllowRestartFalse() throws Exception {
 
 		String METHOD = "testDeciderTransitionFromSplitAndAllowRestartFalse";
 
 		try {
-			Reporter.log("Build job parameters.<p>");    
+			logger.info("Build job parameters.<p>");    
 
 			Properties jobParameters = new Properties();
 			jobParameters.setProperty("step.complete.but.force.job.stopped.status", FORCE_STOP_EXITSTATUS);
@@ -906,7 +890,7 @@ public class DeciderTests implements StatusConstants {
 			jobParameters.setProperty("stop.job.after.this.step", "split1flow1step2");
 			jobParameters.setProperty("stop.job.after.this.step2", "split1flow2step2");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("decider_transitions_from_split_on_restart", jobParameters); 
 
 			assertObjEquals(BatchStatus.STOPPED, jobExec.getBatchStatus());
@@ -916,7 +900,7 @@ public class DeciderTests implements StatusConstants {
 			restartJobParameters.setProperty("stop.job.after.this.step", "None");
 			restartJobParameters.setProperty("is.restart", "true");
 
-			Reporter.log("Invoke restartJobAndWaitForResult<p>");
+			logger.info("Invoke restartJobAndWaitForResult<p>");
 			JobExecution jobExec2 = jobOp.restartJobAndWaitForResult(jobExec.getExecutionId(), restartJobParameters);
 
 			assertObjEquals("4:split1flow2step2_CONTINUE", jobExec2.getExitStatus());
@@ -929,8 +913,8 @@ public class DeciderTests implements StatusConstants {
 
 
 	private static void handleException(String methodName, Exception e) throws Exception {
-		Reporter.log("Caught exception: " + e.getMessage()+"<p>");
-		Reporter.log(methodName + " failed<p>");
+		logger.info("Caught exception: " + e.getMessage()+"<p>");
+		logger.info(methodName + " failed<p>");
 		throw e;
 	}
 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ExecuteTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ExecuteTests.java
@@ -29,30 +29,16 @@ import javax.batch.runtime.JobExecution;
 import com.ibm.jbatch.tck.artifacts.specialized.BatchletUsingStepContextImpl;
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
 
-import org.junit.BeforeClass;
-import org.testng.Reporter;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.*;
 
 public class ExecuteTests {
 
 	private final static Logger logger = Logger.getLogger(ExecuteTests.class.getName());
-	private static JobOperatorBridge jobOp = null;
+	private JobOperatorBridge jobOp = null;
 
 
-	public static void setup(String[] args, Properties props) throws Exception {
-		String METHOD = "setup";
-
-		try {
-			jobOp = new JobOperatorBridge();  
-		} catch (Exception e) {
-			handleException(METHOD, e);
-		}
-	}
-
-	@BeforeMethod
-	@BeforeClass
-	public static void setUp() throws Exception {
+	@BeforeEach
+	public void setUp() throws Exception {
 		jobOp = new JobOperatorBridge();
 	}
 
@@ -63,8 +49,8 @@ public class ExecuteTests {
 	}
 
 	private static void handleException(String methodName, Exception e) throws Exception {
-		Reporter.log("Caught exception: " + e.getMessage()+"<p>");
-		Reporter.log(methodName + " failed<p>");
+		logger.info("Caught exception: " + e.getMessage()+"<p>");
+		logger.info(methodName + " failed<p>");
 		throw e;
 	}
 
@@ -74,21 +60,21 @@ public class ExecuteTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testMyStepContextBatchlet() throws Exception { 
 
 		String METHOD = "testMyStepContextBatchlet";
 
 		try {
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("test_batchlet_stepCtx"); 
 
-			Reporter.log("EXPECTED JobExecution getExitStatus()="+BatchletUsingStepContextImpl.GOOD_JOB_EXIT_STATUS+"<p>");
-			Reporter.log("ACTUAL JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
-			Reporter.log("EXPECTED JobExecution getBatchStatus()=COMPLETED<p>");
-			Reporter.log("ACTUAL JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("EXPECTED JobExecution getExitStatus()="+BatchletUsingStepContextImpl.GOOD_JOB_EXIT_STATUS+"<p>");
+			logger.info("ACTUAL JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
+			logger.info("EXPECTED JobExecution getBatchStatus()=COMPLETED<p>");
+			logger.info("ACTUAL JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(BatchletUsingStepContextImpl.GOOD_JOB_EXIT_STATUS, jobExec.getExitStatus());
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 		} catch (Exception e) {

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ExecutionTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ExecutionTests.java
@@ -29,41 +29,25 @@ import javax.batch.runtime.JobExecution;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
 
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.testng.Reporter;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.*;
 
 public class ExecutionTests {
 
 	private final static Logger logger = Logger.getLogger(ExecutionTests.class.getName());
 
-	private static JobOperatorBridge jobOp;
+	private JobOperatorBridge jobOp;
 
-	public static void setup(String[] args, Properties props) throws Exception {
-		String METHOD = "setup";
-
-		try {
-			jobOp = new JobOperatorBridge();  
-		} catch (Exception e) {
-			handleException(METHOD, e);
-		}
-	}
-
-	@BeforeMethod
-	@BeforeClass
-	public static void setUp() throws Exception {
+	@BeforeEach
+	public void setUp() throws Exception {
 		jobOp = new JobOperatorBridge();
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void cleanup() throws Exception {
 	}
 
 	private void begin(String str) {
-		Reporter.log("Begin test method: " + str);
+		logger.info("Begin test method: " + str);
 	}
 
 	/*
@@ -72,18 +56,18 @@ public class ExecutionTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test  
+  
 	public void testInvokeJobWithOneBatchletStep() throws Exception {
 		String METHOD = "testInvokeJobWithOneBatchletStep";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: job_batchlet_1step.xml<p>");
+			logger.info("Locate job XML file: job_batchlet_1step.xml<p>");
 
-			Reporter.log("Invoking startJobAndWaitForResult for Execution #1<p>");
+			logger.info("Invoking startJobAndWaitForResult for Execution #1<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_batchlet_1step");
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -96,18 +80,18 @@ public class ExecutionTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testInvokeJobWithTwoStepSequenceOfBatchlets() throws Exception {
 		String METHOD = "testInvokeJobWithTwoStepSequenceOfBatchlets";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: job_batchlet_2steps.xml<p>");
+			logger.info("Locate job XML file: job_batchlet_2steps.xml<p>");
 
-			Reporter.log("Invoking startJobAndWaitForResult for Execution #1<p>");
+			logger.info("Invoking startJobAndWaitForResult for Execution #1<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_batchlet_2steps");
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -120,18 +104,18 @@ public class ExecutionTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testInvokeJobWithFourStepSequenceOfBatchlets() throws Exception {
 		String METHOD = "testInvokeJobWithFourStepSequenceOfBatchlets";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: job_batchlet_4steps.xml<p>");
+			logger.info("Locate job XML file: job_batchlet_4steps.xml<p>");
 
-			Reporter.log("Invoking startJobAndWaitForResult for Execution #1<p>");
+			logger.info("Invoking startJobAndWaitForResult for Execution #1<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_batchlet_4steps");
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -144,18 +128,18 @@ public class ExecutionTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test  
+  
 	public void testInvokeJobWithNextElement() throws Exception {
 		String METHOD = "testInvokeJobWithNextElement";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: job_batchlet_nextElement.xml<p>");
+			logger.info("Locate job XML file: job_batchlet_nextElement.xml<p>");
 
-			Reporter.log("Invoking startJobAndWaitForResult for Execution #1<p>");
+			logger.info("Invoking startJobAndWaitForResult for Execution #1<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_batchlet_nextElement");
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -168,19 +152,19 @@ public class ExecutionTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test  
+  
 	public void testInvokeJobWithFailElement() throws Exception {
 		String METHOD = "testInvokeJobWithFailElement";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: job_batchlet_failElement.xml<p>");
+			logger.info("Locate job XML file: job_batchlet_failElement.xml<p>");
 
-			Reporter.log("Invoking startJobAndWaitForResult for Execution #1<p>");
+			logger.info("Invoking startJobAndWaitForResult for Execution #1<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_batchlet_failElement");
 
-			Reporter.log("execution #1 JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals("TEST_FAIL", jobExec.getExitStatus());
 			assertObjEquals(BatchStatus.FAILED, jobExec.getBatchStatus());
 		} catch (Exception e) {
@@ -194,18 +178,18 @@ public class ExecutionTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test  
+  
 	public void testInvokeJobWithStopElement() throws Exception {
 		String METHOD = "testInvokeJobWithStopElement";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: job_batchlet_stopElement.xml<p>");
+			logger.info("Locate job XML file: job_batchlet_stopElement.xml<p>");
 
-			Reporter.log("Invoking startJobAndWaitForResult for Execution #1<p>");
+			logger.info("Invoking startJobAndWaitForResult for Execution #1<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_batchlet_stopElement");
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.STOPPED, jobExec.getBatchStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -218,19 +202,19 @@ public class ExecutionTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test  
+  
 	public void testInvokeJobWithEndElement() throws Exception {
 		String METHOD = "testInvokeJobWithEndElement";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: job_batchlet_endElement.xml<p>");
+			logger.info("Locate job XML file: job_batchlet_endElement.xml<p>");
 
-			Reporter.log("Invoking startJobAndWaitForResult for Execution #1<p>");
+			logger.info("Invoking startJobAndWaitForResult for Execution #1<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_batchlet_endElement");
 
-			Reporter.log("execution #1 JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getExitStatus()="+jobExec.getExitStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals("TEST_ENDED", jobExec.getExitStatus());
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 		} catch (Exception e) {
@@ -244,18 +228,18 @@ public class ExecutionTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testInvokeJobSimpleChunk() throws Exception {
 		String METHOD = "testInvokeJobSimpleChunk";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: job_chunk_simple.xml<p>");
+			logger.info("Locate job XML file: job_chunk_simple.xml<p>");
 
-			Reporter.log("Invoking startJobAndWaitForResult for Execution #1<p>");
+			logger.info("Invoking startJobAndWaitForResult for Execution #1<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_chunk_simple");
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -267,20 +251,20 @@ public class ExecutionTests {
 	 * @assertion: FIXME
 	 * @test_Strategy: FIXME
 	 */
-	@org.junit.Test
-	@Test(enabled=false) // Disabling per Bug 5379
-	@Ignore("Bug 5379.  Decided to exclude this test.")
+
+	@Test // Disabling per Bug 5379
+	@Disabled("Bug 5379.  Decided to exclude this test.")
 	public void testInvokeJobChunkWithFullAttributes() throws Exception {
 		String METHOD = "testInvokeJobChunkWithFullAttributes";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: job_chunk_full_attributes.xml<p>");
+			logger.info("Locate job XML file: job_chunk_full_attributes.xml<p>");
 
-			Reporter.log("Invoking startJobAndWaitForResult for Execution #1<p>");
+			logger.info("Invoking startJobAndWaitForResult for Execution #1<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_chunk_full_attributes");
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -294,18 +278,18 @@ public class ExecutionTests {
 	 * 	and archive loading are unable to find the specified artifact.
 	 */
 	@Test
-	@org.junit.Test  
+  
 	public void testInvokeJobUsingTCCL() throws Exception {
 		String METHOD = "testInvokeJobUsingTCCL";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Run job using job XML file: test_artifact_load_classloader<p>");
+			logger.info("Run job using job XML file: test_artifact_load_classloader<p>");
 
-			Reporter.log("Invoking startJobAndWaitForResult for Execution #1<p>");
+			logger.info("Invoking startJobAndWaitForResult for Execution #1<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("test_artifact_load_classloader");
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -318,18 +302,18 @@ public class ExecutionTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testCheckpoint() throws Exception {
 		String METHOD = "testCheckpoint";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: job_chunk_checkpoint.xml<p>");
+			logger.info("Locate job XML file: job_chunk_checkpoint.xml<p>");
 
-			Reporter.log("Invoking startJobAndWaitForResult for Execution #1<p>");
+			logger.info("Invoking startJobAndWaitForResult for Execution #1<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_chunk_checkpoint");
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -342,18 +326,18 @@ public class ExecutionTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testSimpleFlow() throws Exception {
 		String METHOD = "testSimpleFlow";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: job_flow_batchlet_4steps.xml<p>");
+			logger.info("Locate job XML file: job_flow_batchlet_4steps.xml<p>");
 
-			Reporter.log("Invoking startJobAndWaitForResult for Execution #1<p>");
+			logger.info("Invoking startJobAndWaitForResult for Execution #1<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_flow_batchlet_4steps");
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -363,8 +347,8 @@ public class ExecutionTests {
 
 
 	private static void handleException(String methodName, Exception e) throws Exception {
-		Reporter.log("Caught exception: " + e.getMessage()+"<p>");
-		Reporter.log(methodName + " failed<p>");
+		logger.info("Caught exception: " + e.getMessage()+"<p>");
+		logger.info(methodName + " failed<p>");
 		throw e;
 	}
 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/FlowTransitioningTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/FlowTransitioningTests.java
@@ -28,16 +28,13 @@ import javax.batch.operations.JobStartException;
 import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.JobExecution;
 
-import org.junit.Before;
-import org.testng.Reporter;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
-
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.*;
 
 public class FlowTransitioningTests {
 
+	private static final Logger logger = Logger.getLogger(FlowTransitioningTests.class.getName());
 	private JobOperatorBridge jobOp = null;
 
 	/**
@@ -55,7 +52,7 @@ public class FlowTransitioningTests {
 	 * @throws IOException
 	 * @throws InterruptedException
 	 */
-	@Test @org.junit.Test
+	@Test
 	public void testFlowTransitionToStep() throws Exception {
 
 		String METHOD = "testFlowTransitionToStep";
@@ -63,9 +60,9 @@ public class FlowTransitioningTests {
 		try {
 
 			String[] transitionList = {"flow1step1", "flow1step2", "flow1step3", "step1"};
-			Reporter.log("starting job");
+			logger.info("starting job");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("flow_transition_to_step", null);
-			Reporter.log("Job Status = " + jobExec.getBatchStatus());
+			logger.info("Job Status = " + jobExec.getBatchStatus());
 
 			String[] jobTransitionList = jobExec.getExitStatus().split(",");
 			assertWithMessage("transitioned to exact number of steps", transitionList.length, jobTransitionList.length);
@@ -74,7 +71,7 @@ public class FlowTransitioningTests {
 			}
 
 			assertWithMessage("Job completed", BatchStatus.COMPLETED, jobExec.getBatchStatus());
-			Reporter.log("Job completed");
+			logger.info("Job completed");
 		} catch (Exception e) {
 			handleException(METHOD, e);
 		}
@@ -111,19 +108,19 @@ public class FlowTransitioningTests {
 	 * @throws InterruptedException
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testFlowTransitionToStepOutOfScope() throws Exception {
 
 		String METHOD = " testFlowTransitionToStepOutOfScope";
 
 		try {
 			boolean seenException = false;
-			Reporter.log("starting job");
+			logger.info("starting job");
 			JobExecution jobExec = null;
 			try {
 				jobExec = jobOp.startJobAndWaitForResult("flow_transition_to_step_out_of_scope", null);
 			} catch (JobStartException e) {
-				Reporter.log("Caught JobStartException:  " + e.getLocalizedMessage());
+				logger.info("Caught JobStartException:  " + e.getLocalizedMessage());
 				seenException = true;
 			}
 
@@ -132,7 +129,7 @@ public class FlowTransitioningTests {
 
 			// If we didn't catch an exception that we require that the implementation fail the job execution.
 			if (!seenException) {
-				Reporter.log("Didn't catch JobStartException, Job Batch Status = " + jobExec.getBatchStatus());
+				logger.info("Didn't catch JobStartException, Job Batch Status = " + jobExec.getBatchStatus());
 				assertWithMessage("Job should have failed because of out of scope execution elements.", 
 						BatchStatus.FAILED, jobExec.getBatchStatus());
 			}
@@ -154,7 +151,7 @@ public class FlowTransitioningTests {
 	 * @throws IOException
 	 * @throws InterruptedException
 	 */
-	@Test @org.junit.Test
+	@Test
 	public void testFlowTransitionToDecision() throws Exception {
 
 		String METHOD = "testFlowTransitionToDecision";
@@ -167,13 +164,13 @@ public class FlowTransitioningTests {
 				<end exit-status="ThatsAllFolks" on="DECIDER_EXIT_STATUS*VERY GOOD INVOCATION" />
 			</decision>
 			 */
-			Reporter.log("starting job");
+			logger.info("starting job");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("flow_transition_to_decision", null);
-			Reporter.log("Job Status = " + jobExec.getBatchStatus());
+			logger.info("Job Status = " + jobExec.getBatchStatus());
 
 			assertWithMessage("Job Exit Status is from decider", exitStatus, jobExec.getExitStatus());
 			assertWithMessage("Job completed", BatchStatus.COMPLETED, jobExec.getBatchStatus());
-			Reporter.log("Job completed");
+			logger.info("Job completed");
 		} catch (Exception e) {
 			handleException(METHOD, e);
 		}
@@ -195,16 +192,16 @@ public class FlowTransitioningTests {
 	 * @throws IOException
 	 * @throws InterruptedException
 	 */
-	@Test @org.junit.Test
+	@Test
 	public void testFlowTransitionWithinFlow() throws Exception {
 
 		String METHOD = "testFlowTransitionWithinFlow";
 
 		try {
 			String[] transitionList = {"flow1step1", "flow1step2", "flow1step3"};
-			Reporter.log("starting job");
+			logger.info("starting job");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("flow_transition_within_flow", null);
-			Reporter.log("Job Status = " + jobExec.getBatchStatus());
+			logger.info("Job Status = " + jobExec.getBatchStatus());
 
 			String[] jobTransitionList = jobExec.getExitStatus().split(",");
 			assertWithMessage("transitioned to exact number of steps", transitionList.length, jobTransitionList.length);
@@ -213,15 +210,15 @@ public class FlowTransitioningTests {
 			}
 
 			assertWithMessage("Job completed", BatchStatus.COMPLETED, jobExec.getBatchStatus());
-			Reporter.log("Job completed");
+			logger.info("Job completed");
 		} catch (Exception e) {
 			handleException(METHOD, e);
 		}
 	}
 
 	private static void handleException(String methodName, Exception e) throws Exception {
-		Reporter.log("Caught exception: " + e.getMessage()+"<p>");
-		Reporter.log(methodName + " failed<p>");
+		logger.info("Caught exception: " + e.getMessage()+"<p>");
+		logger.info(methodName + " failed<p>");
 		throw e;
 	}
 
@@ -242,13 +239,12 @@ public class FlowTransitioningTests {
 
 	}
 
-	@BeforeTest
-	@Before
+	@BeforeEach
 	public void beforeTest() throws ClassNotFoundException {
 		jobOp = new JobOperatorBridge(); 
 	}
 
-	@AfterTest
+	@AfterEach
 	public void afterTest() {
 		jobOp = null;
 	}

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/JobAttributeRestartTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/JobAttributeRestartTests.java
@@ -32,15 +32,13 @@ import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.JobExecution;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import java.util.logging.Logger;
 
-import org.junit.Before;
-import org.testng.Reporter;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.*;
 
 public class JobAttributeRestartTests {
 
+	private static final Logger logger = Logger.getLogger(JobAttributeRestartTests.class.getName());
 	private JobOperatorBridge jobOp = null;
 
 	private long TIMEOUT = 5000L;
@@ -59,30 +57,30 @@ public class JobAttributeRestartTests {
 	 * @throws NoSuchJobExecutionException 
 	 * @throws JobInstanceAlreadyCompleteException 
 	 */
-	@Test @org.junit.Test
+	@Test
 	public void testJobAttributeRestartableTrue() throws Exception {
 
 		String METHOD = "testJobAttributeRestartableTrue";
 
 		try {
-			Reporter.log("starting job");
+			logger.info("starting job");
 			Properties jobParams = new Properties();
-			Reporter.log("execution.number=1<p>");
+			logger.info("execution.number=1<p>");
 			jobParams.put("execution.number", "1");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_attributes_restart_true_test", jobParams);
 
-			Reporter.log("Job Status = " + jobExec.getBatchStatus());
+			logger.info("Job Status = " + jobExec.getBatchStatus());
 			assertWithMessage("Job failed ", BatchStatus.FAILED, jobExec.getBatchStatus());
 
-			Reporter.log("restarting job");
+			logger.info("restarting job");
 			Properties restartParams = new Properties();
-			Reporter.log("execution.number=2<p>");
+			logger.info("execution.number=2<p>");
 			restartParams.put("execution.number", "2");
 			JobExecution newJobExec = jobOp.restartJobAndWaitForResult(jobExec.getExecutionId(), restartParams);
 
-			Reporter.log("Job Status = " + newJobExec.getBatchStatus());
+			logger.info("Job Status = " + newJobExec.getBatchStatus());
 			assertWithMessage("Job completed", BatchStatus.COMPLETED, newJobExec.getBatchStatus());
-			Reporter.log("job completed");
+			logger.info("job completed");
 		} catch (Exception e) {
 			handleException(METHOD, e);
 		}
@@ -91,8 +89,8 @@ public class JobAttributeRestartTests {
 
 
 	private static void handleException(String methodName, Exception e) throws Exception {
-		Reporter.log("Caught exception: " + e.getMessage()+"<p>");
-		Reporter.log(methodName + " failed<p>");
+		logger.info("Caught exception: " + e.getMessage()+"<p>");
+		logger.info(methodName + " failed<p>");
 		throw e;
 	}
 
@@ -113,13 +111,12 @@ public class JobAttributeRestartTests {
 
 	}
 
-	@BeforeTest
-	@Before
+	@BeforeEach
 	public void beforeTest() throws ClassNotFoundException {
 		jobOp = new JobOperatorBridge(); 
 	}
 
-	@AfterTest
+	@AfterEach
 	public void afterTest() {
 		jobOp = null;
 	}

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/JobExecutableSequenceTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/JobExecutableSequenceTests.java
@@ -28,16 +28,13 @@ import javax.batch.operations.JobStartException;
 import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.JobExecution;
 
-import org.junit.Before;
-import org.testng.Reporter;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
-
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.*;
 
 public class JobExecutableSequenceTests {
 
+	private static final Logger logger = Logger.getLogger(JobExecutableSequenceTests.class.getName());
 	private JobOperatorBridge jobOp = null;
 
 	/**
@@ -53,38 +50,38 @@ public class JobExecutableSequenceTests {
 	 * @throws InterruptedException
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testJobExecutableSequenceToUnknown() throws Exception {
 
 		String METHOD = "testJobExecutableSequenceToUnknown";
 
 		try {
 
-			Reporter.log("starting job");
+			logger.info("starting job");
 			JobExecution jobExec = null;
 			boolean seenException = false;
 			try {
 				jobExec = jobOp.startJobAndWaitForResult("job_executable_sequence_invalid", null);
 			} catch (JobStartException e) {
-				Reporter.log("Caught JobStartException:  " + e.getLocalizedMessage());
+				logger.info("Caught JobStartException:  " + e.getLocalizedMessage());
 				seenException = true;
 			}
 			// If we caught an exception we'd expect that a JobExecution would not have been created,
 			// though we won't validate that it wasn't created.  
 			// If we didn't catch an exception that we require that the implementation fail the job execution.
 			if (!seenException) {
-				Reporter.log("Didn't catch JobStartException, Job Batch Status = " + jobExec.getBatchStatus());
+				logger.info("Didn't catch JobStartException, Job Batch Status = " + jobExec.getBatchStatus());
 				assertWithMessage("Job should have failed because of out of scope execution elements.", BatchStatus.FAILED, jobExec.getBatchStatus());
 			}
-			Reporter.log("job failed");
+			logger.info("job failed");
 		} catch (Exception e) {
 			handleException(METHOD, e);
 		}
 	}
 
 	private static void handleException(String methodName, Exception e) throws Exception {
-		Reporter.log("Caught exception: " + e.getMessage()+"<p>");
-		Reporter.log(methodName + " failed<p>");
+		logger.info("Caught exception: " + e.getMessage()+"<p>");
+		logger.info(methodName + " failed<p>");
 		throw e;
 	}
 
@@ -105,13 +102,12 @@ public class JobExecutableSequenceTests {
 
 	}
 
-	@BeforeTest
-	@Before
+	@BeforeEach
 	public void beforeTest() throws ClassNotFoundException {
 		jobOp = new JobOperatorBridge(); 
 	}
 
-	@AfterTest
+	@AfterEach
 	public void afterTest() {
 		jobOp = null;
 	}

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/JobLevelPropertiesTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/JobLevelPropertiesTests.java
@@ -28,15 +28,13 @@ import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.JobExecution;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import java.util.logging.Logger;
 
-import org.junit.Before;
-import org.testng.Reporter;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.*;
 
 public class JobLevelPropertiesTests {
 
+	private static final Logger logger = Logger.getLogger(JobLevelPropertiesTests.class.getName());
 	private JobOperatorBridge jobOp = null;
 	
 	private String FOO_VALUE = "bar";
@@ -52,7 +50,7 @@ public class JobLevelPropertiesTests {
 	 * @throws IOException
 	 * @throws InterruptedException
 	 */
-	@Test @org.junit.Test
+	@Test
 	public void testJobLevelPropertiesCount() throws Exception {
 		
 		String METHOD = "testJobLevelPropertiesCount";
@@ -61,13 +59,13 @@ public class JobLevelPropertiesTests {
 		jobParams.put(SHOULD_BE_UNAVAILABLE_PROP_PREFIX + ".parm1", "should.not.appear.in.job.context.properties");
 		
 		try {
-			Reporter.log("starting job");
+			logger.info("starting job");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_level_properties_count", jobParams);
 	
-			Reporter.log("Job Status = " + jobExec.getBatchStatus());
+			logger.info("Job Status = " + jobExec.getBatchStatus());
 			assertWithMessage("Job completed", BatchStatus.COMPLETED, jobExec.getBatchStatus());
 			assertWithMessage("Job completed", "VERY GOOD INVOCATION", jobExec.getExitStatus());
-			Reporter.log("job completed");
+			logger.info("job completed");
 			
 		} catch (Exception e) {
             handleException(METHOD, e);
@@ -83,23 +81,23 @@ public class JobLevelPropertiesTests {
 	 * @throws IOException
 	 * @throws InterruptedException
 	 */
-	@Test @org.junit.Test
+	@Test
 	public void testJobLevelPropertiesPropertyValue() throws Exception {
 		
 		String METHOD = "testJobLevelPropertiesPropertyValue";
 
 
 		try {
-			Reporter.log("starting job");
+			logger.info("starting job");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_level_properties_value");
 	
-			Reporter.log("Job Status = " + jobExec.getBatchStatus());
+			logger.info("Job Status = " + jobExec.getBatchStatus());
 			assertWithMessage("Job completed", BatchStatus.COMPLETED, jobExec.getBatchStatus());			
-			Reporter.log("job completed");
+			logger.info("job completed");
 			
 			assertWithMessage("Property value", FOO_VALUE, jobExec.getExitStatus());
 			
-			Reporter.log("Job batchlet return code is the job property foo value " + FOO_VALUE);
+			logger.info("Job batchlet return code is the job property foo value " + FOO_VALUE);
 		} catch (Exception e) {
             handleException(METHOD, e);
         }
@@ -112,29 +110,29 @@ public class JobLevelPropertiesTests {
 	 * 
 	 * @throws InterruptedException
 	 */
-	@Test @org.junit.Test
+	@Test
 	public void testJobLevelPropertiesShouldNotBeAvailableThroughStepContext() throws Exception {
 		
 		String METHOD = "testJobLevelPropertiesShouldNotBeAvailableThroughStepContext";
 		
 		try {
-			Reporter.log("starting job");
+			logger.info("starting job");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_level_properties_scope");
 	
-			Reporter.log("Job Status = " + jobExec.getBatchStatus());
+			logger.info("Job Status = " + jobExec.getBatchStatus());
 			assertWithMessage("Job completed", BatchStatus.COMPLETED, jobExec.getBatchStatus());
-			Reporter.log("job completed");
+			logger.info("job completed");
 			
 			assertWithMessage("Job Level Property is not available through step context", BatchStatus.COMPLETED.name(), jobExec.getExitStatus());
-			Reporter.log("Job batchlet return code is the job.property read through step context (expected value=COMPLETED) " + jobExec.getExitStatus());
+			logger.info("Job batchlet return code is the job.property read through step context (expected value=COMPLETED) " + jobExec.getExitStatus());
 		} catch (Exception e) {
             handleException(METHOD, e);
         }
 	}
 	
 	 private static void handleException(String methodName, Exception e) throws Exception {
-	        Reporter.log("Caught exception: " + e.getMessage() + "<p>");
-	        Reporter.log(methodName + " failed<p>");
+	        logger.info("Caught exception: " + e.getMessage() + "<p>");
+	        logger.info(methodName + " failed<p>");
 	        throw e;
 	    }
 	 
@@ -155,14 +153,13 @@ public class JobLevelPropertiesTests {
 		
 		}
 
-	@BeforeTest
-    @Before
+	@BeforeEach
 	public void beforeTest() throws ClassNotFoundException {
 		jobOp = new JobOperatorBridge();
 		
 	}
 
-	@AfterTest
+	@AfterEach
 	public void afterTest() {
 		jobOp = null;
 	}

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/JobOperatorTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/JobOperatorTests.java
@@ -35,31 +35,16 @@ import javax.batch.runtime.JobInstance;
 import javax.batch.runtime.Metric;
 import javax.batch.runtime.StepExecution;
 
-import org.junit.BeforeClass;
-import org.testng.Reporter;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
 import com.ibm.jbatch.tck.utils.TCKJobExecutionWrapper;
+import org.junit.jupiter.api.*;
 
 public class JobOperatorTests {
 
 	private final static Logger logger = Logger.getLogger(JobOperatorTests.class.getName());
 
-	private static JobOperatorBridge jobOp;
-
-	public static void setup(String[] args, Properties props) throws Exception {
-
-		String METHOD = "setup";
-
-		try {
-			jobOp = new JobOperatorBridge();
-		} catch (Exception e) {
-			handleException(METHOD, e);
-		}
-	}
+	private JobOperatorBridge jobOp;
 
 	/* cleanup */
 	public void  cleanup()
@@ -67,23 +52,22 @@ public class JobOperatorTests {
 
 	}
 
-	@BeforeMethod
-	@BeforeClass
-	public static void setUp() throws Exception {
+	@BeforeEach
+	public void setUp() throws Exception {
 		jobOp = new JobOperatorBridge();
 	}
 
-	@AfterMethod
-	public static void tearDown() throws Exception {
+	@AfterEach
+	public void tearDown() throws Exception {
 	}
 
 	private void begin(String str) {
-		Reporter.log("Begin test method: " + str);
+		logger.info("Begin test method: " + str);
 	}
 
 	private static void handleException(String methodName, Exception e) throws Exception {
-		Reporter.log("Caught exception: " + e.getMessage()+"<p>");
-		Reporter.log(methodName + " failed<p>");
+		logger.info("Caught exception: " + e.getMessage()+"<p>");
+		logger.info(methodName + " failed<p>");
 		throw e;
 	}
 
@@ -95,19 +79,19 @@ public class JobOperatorTests {
 	 * @throws JobStartException               
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testJobOperatorStart() throws Exception {
 
 		String METHOD = "testJobOperatorStart";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: job_batchlet_1step.xml<p>");
+			logger.info("Locate job XML file: job_batchlet_1step.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_batchlet_1step");
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -129,21 +113,21 @@ public class JobOperatorTests {
 	 *                 
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testJobOperatorRestart() throws Exception {
 
 		String METHOD = "testJobOperatorRestart";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
-			Reporter.log("execution.number=1<p>");
-			Reporter.log("readrecord.fail=12<p>");
-			Reporter.log("app.arraysize=30<p>");
-			Reporter.log("app.writepoints=0,5,10,15,20,25,30<p>");
-			Reporter.log("app.next.writepoints=10,15,20,25,30<p>");
-			Reporter.log("app.commitinterval=5<p>");
+			logger.info("execution.number=1<p>");
+			logger.info("readrecord.fail=12<p>");
+			logger.info("app.arraysize=30<p>");
+			logger.info("app.writepoints=0,5,10,15,20,25,30<p>");
+			logger.info("app.next.writepoints=10,15,20,25,30<p>");
+			logger.info("app.commitinterval=5<p>");
 			jobParams.put("execution.number", "1");
 			jobParams.put("readrecord.fail", "12");
 			jobParams.put("app.arraysize", "30");
@@ -151,27 +135,27 @@ public class JobOperatorTests {
 			jobParams.put("app.next.writepoints", "10,15,20,25,30");
 			jobParams.put("app.commitinterval", "5");
 
-			Reporter.log("Locate job XML file: chunksize5commitinterval5.xml<p>");
+			logger.info("Locate job XML file: chunksize5commitinterval5.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			TCKJobExecutionWrapper execution1 = jobOp.startJobAndWaitForResult("chunksize5commitinterval5", jobParams);
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
-			Reporter.log("execution #1 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
 			assertWithMessage("Testing execution #1", BatchStatus.FAILED, execution1.getBatchStatus());
 			assertWithMessage("Testing execution #1", "FAILED", execution1.getExitStatus());
 
 			long jobInstanceId = execution1.getInstanceId();
 			long lastExecutionId = execution1.getExecutionId();
 			TCKJobExecutionWrapper exec = null;
-			Reporter.log("Got Job instance id: " + jobInstanceId + "<p>");
-			Reporter.log("Got Job execution id: " + lastExecutionId + "<p>");
+			logger.info("Got Job instance id: " + jobInstanceId + "<p>");
+			logger.info("Got Job execution id: " + lastExecutionId + "<p>");
 			{
-				Reporter.log("Invoke restartJobAndWaitForResult for execution id: " + lastExecutionId + "<p>");
+				logger.info("Invoke restartJobAndWaitForResult for execution id: " + lastExecutionId + "<p>");
 				exec = jobOp.restartJobAndWaitForResult(lastExecutionId, jobParams);
-				Reporter.log("execution #2 JobExecution getBatchStatus()="+exec.getBatchStatus()+"<p>");
-				Reporter.log("execution #2 JobExecution getExitStatus()="+exec.getExitStatus()+"<p>");
-				Reporter.log("execution #2 Job instance id="+exec.getInstanceId()+"<p>");
+				logger.info("execution #2 JobExecution getBatchStatus()="+exec.getBatchStatus()+"<p>");
+				logger.info("execution #2 JobExecution getExitStatus()="+exec.getExitStatus()+"<p>");
+				logger.info("execution #2 Job instance id="+exec.getInstanceId()+"<p>");
 				assertWithMessage("Testing execution #2", BatchStatus.COMPLETED, exec.getBatchStatus());
 				assertWithMessage("Testing execution #2", "COMPLETED", exec.getExitStatus());
 				assertWithMessage("Testing execution #2", jobInstanceId, exec.getInstanceId());  
@@ -204,21 +188,21 @@ public class JobOperatorTests {
 	 *                 
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testJobOperatorRestartAlreadyCompleteException() throws Exception {
 
 		String METHOD = "testJobOperatorRestartAlreadyCompleteException";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
-			Reporter.log("execution.number=1<p>");
-			Reporter.log("readrecord.fail=12<p>");
-			Reporter.log("app.arraysize=30<p>");
-			Reporter.log("app.writepoints=0,5,10,15,20,25,30<p>");
-			Reporter.log("app.next.writepoints=10,15,20,25,30<p>");
-			Reporter.log("app.commitinterval=5<p>");
+			logger.info("execution.number=1<p>");
+			logger.info("readrecord.fail=12<p>");
+			logger.info("app.arraysize=30<p>");
+			logger.info("app.writepoints=0,5,10,15,20,25,30<p>");
+			logger.info("app.next.writepoints=10,15,20,25,30<p>");
+			logger.info("app.commitinterval=5<p>");
 			jobParams.put("execution.number", "1");
 			jobParams.put("readrecord.fail", "12");
 			jobParams.put("app.arraysize", "30");
@@ -226,43 +210,43 @@ public class JobOperatorTests {
 			jobParams.put("app.next.writepoints", "10,15,20,25,30");
 			jobParams.put("app.commitinterval", "5");
 
-			Reporter.log("Locate job XML file: chunksize5commitinterval5.xml<p>");
+			logger.info("Locate job XML file: chunksize5commitinterval5.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			TCKJobExecutionWrapper execution1 = jobOp.startJobAndWaitForResult("chunksize5commitinterval5", jobParams);
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
-			Reporter.log("execution #1 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
 			assertWithMessage("Testing execution #1", BatchStatus.FAILED, execution1.getBatchStatus());
 			assertWithMessage("Testing execution #1", "FAILED", execution1.getExitStatus());
 
 			long jobInstanceId = execution1.getInstanceId();
 			long firstExecutionId = execution1.getExecutionId();
 			TCKJobExecutionWrapper exec = null;
-			Reporter.log("Got Job instance id: " + jobInstanceId + "<p>");
-			Reporter.log("Got Job execution id: " + firstExecutionId + "<p>");
+			logger.info("Got Job instance id: " + jobInstanceId + "<p>");
+			logger.info("Got Job execution id: " + firstExecutionId + "<p>");
 			{
-				Reporter.log("Invoke restartJobAndWaitForResult for execution id: " + firstExecutionId + "<p>");
+				logger.info("Invoke restartJobAndWaitForResult for execution id: " + firstExecutionId + "<p>");
 				exec = jobOp.restartJobAndWaitForResult(firstExecutionId, jobParams);
-				Reporter.log("execution #2 JobExecution getBatchStatus()="+exec.getBatchStatus()+"<p>");
-				Reporter.log("execution #2 JobExecution getExitStatus()="+exec.getExitStatus()+"<p>");
-				Reporter.log("execution #2 Job instance id="+exec.getInstanceId()+"<p>");
+				logger.info("execution #2 JobExecution getBatchStatus()="+exec.getBatchStatus()+"<p>");
+				logger.info("execution #2 JobExecution getExitStatus()="+exec.getExitStatus()+"<p>");
+				logger.info("execution #2 Job instance id="+exec.getInstanceId()+"<p>");
 				assertWithMessage("Testing execution #2", BatchStatus.COMPLETED, exec.getBatchStatus());
 				assertWithMessage("Testing execution #2", "COMPLETED", exec.getExitStatus());
 				assertWithMessage("Testing execution #2", jobInstanceId, exec.getInstanceId());  
 			}
 
 			long secondExecutionId = exec.getExecutionId();
-			Reporter.log("execution #2 Job execution id="+ secondExecutionId+"<p>");
+			logger.info("execution #2 Job execution id="+ secondExecutionId+"<p>");
 
 
 			// Restart from second execution id (not first, see strategy comment above).
-			Reporter.log("Now invoke restart again, expecting JobExecutionAlreadyCompleteException, for execution id: " + secondExecutionId + "<p>");
+			logger.info("Now invoke restart again, expecting JobExecutionAlreadyCompleteException, for execution id: " + secondExecutionId + "<p>");
 			boolean seenException = false;
 			try {
 				jobOp.restartJobAndWaitForResult(secondExecutionId, jobParams);
 			} catch (JobExecutionAlreadyCompleteException e) {
-				Reporter.log("Caught JobExecutionAlreadyCompleteException as expected<p>");
+				logger.info("Caught JobExecutionAlreadyCompleteException as expected<p>");
 				seenException = true;
 			}
 			assertWithMessage("Caught JobExecutionAlreadyCompleteException for bad restart #2" , seenException);
@@ -289,7 +273,7 @@ public class JobOperatorTests {
 	 *                 
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testJobOperatorAbandonJobDuringARestart() throws Exception {
 
 		String METHOD = "testJobOperatorAbandonJobDuringARestart";
@@ -298,50 +282,50 @@ public class JobOperatorTests {
 		String DEFAULT_SLEEP_TIME = "5000";
 
 		try {
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
 			jobParams.put("execution.number", "1");
-			Reporter.log("execution.number=1<p>");
+			logger.info("execution.number=1<p>");
 			String sleepTime = System.getProperty("JobOperatorTests.testJobOperatorTestAbandonActiveRestart.sleep",DEFAULT_SLEEP_TIME);
 			jobParams.put("sleep.time", sleepTime);
-			Reporter.log("sleep.time=" + sleepTime + "<p>");
+			logger.info("sleep.time=" + sleepTime + "<p>");
 			
 
-			Reporter.log("Locate job XML file: abandonActiveRestart.xml<p>");
+			logger.info("Locate job XML file: abandonActiveRestart.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			TCKJobExecutionWrapper execution1 = jobOp.startJobAndWaitForResult("abandonActiveRestart", jobParams);
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
-			Reporter.log("execution #1 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
 			assertWithMessage("Testing execution #1", BatchStatus.FAILED, execution1.getBatchStatus());
 			assertWithMessage("Testing execution #1", "FAILED", execution1.getExitStatus());
 
 			long jobInstanceId = execution1.getInstanceId();
 			long firstExecutionId = execution1.getExecutionId();
 			TCKJobExecutionWrapper exec = null;
-			Reporter.log("Got Job instance id: " + jobInstanceId + "<p>");
-			Reporter.log("Got Job execution id: " + firstExecutionId + "<p>");
+			logger.info("Got Job instance id: " + jobInstanceId + "<p>");
+			logger.info("Got Job execution id: " + firstExecutionId + "<p>");
 			
 			jobParams = new Properties();
 			jobParams.put("execution.number", "2");
-			Reporter.log("execution.number=2<p>");
+			logger.info("execution.number=2<p>");
 			sleepTime = System.getProperty("JobOperatorTests.testJobOperatorTestAbandonActiveRestart.sleep",DEFAULT_SLEEP_TIME);
 			jobParams.put("sleep.time", sleepTime);
-			Reporter.log("sleep.time=" + sleepTime + "<p>");
+			logger.info("sleep.time=" + sleepTime + "<p>");
 			
-			Reporter.log("Invoke restartJobWithoutWaitingForResult for execution id: " + firstExecutionId + "<p>");
+			logger.info("Invoke restartJobWithoutWaitingForResult for execution id: " + firstExecutionId + "<p>");
 			exec = jobOp.restartJobWithoutWaitingForResult(firstExecutionId, jobParams);
 			long secondExecutionId = exec.getExecutionId();			
 			{
-				Reporter.log("Invoke restartJobAndWaitForResult for execution id: " + firstExecutionId + "<p>");
+				logger.info("Invoke restartJobAndWaitForResult for execution id: " + firstExecutionId + "<p>");
 				
 				boolean seen = false;
 				try {
 					jobOp.abandonJobExecution(secondExecutionId);
 				}
 				catch (JobExecutionIsRunningException jobRunningEx){
-					Reporter.log("Caught JobExecutionIsRunningException as expected<p>");
+					logger.info("Caught JobExecutionIsRunningException as expected<p>");
 					seen = true;
 				}
 				assertWithMessage("Did not see expected JobExecutionIsRunningException for abandon attempt during restart" , seen);
@@ -370,7 +354,7 @@ public class JobOperatorTests {
 	 *                 
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testJobOperatorRestartJobAlreadyAbandoned() throws Exception {
 
 		String METHOD = "testJobOperatorRestartAlreadyCompleteException";
@@ -379,22 +363,22 @@ public class JobOperatorTests {
 		String DEFAULT_SLEEP_TIME = "1";
 
 		try {
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
 			jobParams.put("execution.number", "1");
-			Reporter.log("execution.number=1<p>");
+			logger.info("execution.number=1<p>");
 			String sleepTime = System.getProperty("JobOperatorTests.testJobOperatorTestRestartAlreadAbandonedJob.sleep",DEFAULT_SLEEP_TIME);
 			jobParams.put("sleep.time", sleepTime);
-			Reporter.log("sleep.time=" + sleepTime + "<p>");
+			logger.info("sleep.time=" + sleepTime + "<p>");
 			
 
-			Reporter.log("Locate job XML file: abandonActiveRestart.xml<p>");
+			logger.info("Locate job XML file: abandonActiveRestart.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			TCKJobExecutionWrapper execution1 = jobOp.startJobAndWaitForResult("abandonActiveRestart", jobParams);
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
-			Reporter.log("execution #1 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
 			assertWithMessage("Testing execution #1", BatchStatus.FAILED, execution1.getBatchStatus());
 			assertWithMessage("Testing execution #1", "FAILED", execution1.getExitStatus());
 			long jobInstanceId = execution1.getInstanceId();
@@ -402,24 +386,24 @@ public class JobOperatorTests {
 			
 			jobOp.abandonJobExecution(firstExecutionId);
 			
-			Reporter.log("Got Job instance id: " + jobInstanceId + "<p>");
-			Reporter.log("Got Job execution id: " + firstExecutionId + "<p>");
+			logger.info("Got Job instance id: " + jobInstanceId + "<p>");
+			logger.info("Got Job execution id: " + firstExecutionId + "<p>");
 			
 			jobParams = new Properties();
 			jobParams.put("execution.number", "2");
-			Reporter.log("execution.number=2<p>");
+			logger.info("execution.number=2<p>");
 			
-			Reporter.log("Invoke restartJobWithoutWaitingForResult for execution id: " + firstExecutionId + "<p>");
+			logger.info("Invoke restartJobWithoutWaitingForResult for execution id: " + firstExecutionId + "<p>");
 						
 			{
-				Reporter.log("Invoke restartJobAndWaitForResult for execution id: " + firstExecutionId + "<p>");
+				logger.info("Invoke restartJobAndWaitForResult for execution id: " + firstExecutionId + "<p>");
 				
 				boolean seen = false;
 				try {
 					jobOp.restartJobWithoutWaitingForResult(firstExecutionId, jobParams);
 				}
 				catch (JobRestartException jobRestartEx){
-					Reporter.log("Caught JobRestartException as expected<p>");
+					logger.info("Caught JobRestartException as expected<p>");
 					seen = true;
 				}
 				assertWithMessage("Caught JobRestartException for abandon attempt during restart" , seen);
@@ -439,7 +423,7 @@ public class JobOperatorTests {
 	 * batch status.
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testInvokeJobWithUserStop() throws Exception {
 		String METHOD = "testInvokeJobWithUserStop";
 		begin(METHOD);
@@ -447,25 +431,25 @@ public class JobOperatorTests {
 		final String DEFAULT_SLEEP_TIME = "1000";
 
 		try {
-			Reporter.log("Locate job XML file: job_batchlet_longrunning.xml<p>");
+			logger.info("Locate job XML file: job_batchlet_longrunning.xml<p>");
 
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParameters = new Properties();
-			Reporter.log("run.indefinitely=true<p>");
+			logger.info("run.indefinitely=true<p>");
 			jobParameters.setProperty("run.indefinitely" , "true");
 
-			Reporter.log("Invoking startJobWithoutWaitingForResult for Execution #1<p>");
+			logger.info("Invoking startJobWithoutWaitingForResult for Execution #1<p>");
 			JobExecution jobExec = jobOp.startJobWithoutWaitingForResult("job_batchlet_longrunning", jobParameters);
 
 			int sleepTime = Integer.parseInt(System.getProperty("JobOperatorTests.testInvokeJobWithUserStop.sleep",DEFAULT_SLEEP_TIME));
-			Reporter.log("Thread.sleep(" +  sleepTime + ")<p>");
+			logger.info("Thread.sleep(" +  sleepTime + ")<p>");
 			Thread.sleep(sleepTime);
 
-			Reporter.log("Invoking stopJobAndWaitForResult for Execution #1<p>");
+			logger.info("Invoking stopJobAndWaitForResult for Execution #1<p>");
 			jobOp.stopJobAndWaitForResult(jobExec);
 
 			JobExecution jobExec2 = jobOp.getJobExecution(jobExec.getExecutionId());
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec2.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+jobExec2.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.STOPPED, jobExec2.getBatchStatus());
 
 		} catch (Exception e) {
@@ -483,19 +467,19 @@ public class JobOperatorTests {
 	 * @throws Exception
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testJobOperatorGetStepExecutions() throws Exception {
 
 		String METHOD = "testJobOperatorGetStepExecutions";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: job_batchlet_1step.xml<p>");
+			logger.info("Locate job XML file: job_batchlet_1step.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_batchlet_1step");
 
-			Reporter.log("Obtaining StepExecutions for execution id: " + jobExec.getExecutionId() + "<p>");
+			logger.info("Obtaining StepExecutions for execution id: " + jobExec.getExecutionId() + "<p>");
 			List<StepExecution> stepExecutions = jobOp.getStepExecutions(jobExec.getExecutionId());
 
 			assertObjEquals(1, stepExecutions.size());
@@ -503,11 +487,11 @@ public class JobOperatorTests {
 			for (StepExecution step : stepExecutions) {
 				// make sure all steps finish successfully
 				showStepState(step);
-				Reporter.log("Step status="+step.getBatchStatus()+"<p>");
+				logger.info("Step status="+step.getBatchStatus()+"<p>");
 				assertObjEquals(BatchStatus.COMPLETED, step.getBatchStatus());
 			}
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -527,7 +511,7 @@ public class JobOperatorTests {
 	 *                 a big deal.
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testJobOpGetJobNames() throws Exception {
 
 		String METHOD = "testJobOpGetJobNames";
@@ -536,13 +520,13 @@ public class JobOperatorTests {
 		String jobName ="job_unique_get_job_names";
 		
 		try {
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			List<String> jobNames = jobOp.getJobNames();
 			jobOp.startJobWithoutWaitingForResult("job_unique_get_job_names");
 			if (jobNames.contains(jobName)) {
-				Reporter.log("JobOperator.getJobNames() already includes " + jobName + ", test is not so useful<p>");
+				logger.info("JobOperator.getJobNames() already includes " + jobName + ", test is not so useful<p>");
 			} else {
-				Reporter.log("JobOperator.getJobNames() does not include " + jobName + " yet.<p>");
+				logger.info("JobOperator.getJobNames() does not include " + jobName + " yet.<p>");
 			}
 
 			jobNames = jobOp.getJobNames();
@@ -561,16 +545,16 @@ public class JobOperatorTests {
 	 * 
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testAbandoned() throws Exception {
 
 		String METHOD = "testAbandoned";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: job_batchlet_4steps.xml<p>");
+			logger.info("Locate job XML file: job_batchlet_4steps.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_batchlet_4steps");
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 
@@ -594,7 +578,7 @@ public class JobOperatorTests {
 	 * 
 	 */
 	@Test  
-	@org.junit.Test
+
 	public void testJobOpgetJobInstanceCount() throws Exception {
 		String METHOD = "testJobOpgetJobInstanceCount";
 		begin(METHOD);
@@ -609,33 +593,33 @@ public class JobOperatorTests {
 				// Can continue.
 			}
 
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
-			Reporter.log("execution.number=1<p>");
-			Reporter.log("readrecord.faile=12<p>");
-			Reporter.log("app.arraysize=30<p>");
-			Reporter.log("app.writepoints=0,5,10,15,20,25,30<p>");
-			Reporter.log("app.commitinterval=5<p>");
+			logger.info("execution.number=1<p>");
+			logger.info("readrecord.faile=12<p>");
+			logger.info("app.arraysize=30<p>");
+			logger.info("app.writepoints=0,5,10,15,20,25,30<p>");
+			logger.info("app.commitinterval=5<p>");
 			jobParams.put("execution.number", "1");
 			jobParams.put("readrecord.fail", "12");
 			jobParams.put("app.arraysize", "30");
 			jobParams.put("app.writepoints", "0,5,10,15,20,25,30");
 			jobParams.put("app.commitinterval", "5");
 
-			Reporter.log("Locate job XML file: chunksize5commitinterval5.xml<p>");
+			logger.info("Locate job XML file: chunksize5commitinterval5.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			TCKJobExecutionWrapper execution1 = jobOp.startJobAndWaitForResult("chunksize5commitinterval5", jobParams);
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
-			Reporter.log("execution #1 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
 			assertWithMessage("Testing execution #1", BatchStatus.FAILED, execution1.getBatchStatus());
 			assertWithMessage("Testing execution #1", "FAILED", execution1.getExitStatus());
 
 			long jobInstanceId = execution1.getInstanceId();
 			long lastExecutionId = execution1.getExecutionId();
-			Reporter.log("Got Job instance id: " + jobInstanceId + "<p>");
-			Reporter.log("Got Job execution id: " + lastExecutionId + "<p>");
+			logger.info("Got Job instance id: " + jobInstanceId + "<p>");
+			logger.info("Got Job execution id: " + lastExecutionId + "<p>");
 
 			int countTrackerAFTER = jobOp.getJobInstanceCount("chunksize5commitinterval5");
 
@@ -644,7 +628,7 @@ public class JobOperatorTests {
 			List<String> jobNames = jobOp.getJobNames();
 
 			for (String jobname : jobNames) {
-				Reporter.log(jobname + " instance count : " + jobOp.getJobInstanceCount(jobname) + " - ");
+				logger.info(jobname + " instance count : " + jobOp.getJobInstanceCount(jobname) + " - ");
 			}
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -661,7 +645,7 @@ public class JobOperatorTests {
 	 * 
 	 */
 	@Test  
-	@org.junit.Test
+
 	public void testJobOpgetJobInstanceCountException() throws Exception {
 		String METHOD = "testJobOpgetJobInstanceCountException";
 		begin(METHOD);
@@ -675,39 +659,39 @@ public class JobOperatorTests {
 				// Can continue.
 			}
 
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
-			Reporter.log("execution.number=1<p>");
-			Reporter.log("readrecord.faile=12<p>");
-			Reporter.log("app.arraysize=30<p>");
-			Reporter.log("app.writepoints=0,5,10,15,20,25,30<p>");
-			Reporter.log("app.commitinterval=5<p>");
+			logger.info("execution.number=1<p>");
+			logger.info("readrecord.faile=12<p>");
+			logger.info("app.arraysize=30<p>");
+			logger.info("app.writepoints=0,5,10,15,20,25,30<p>");
+			logger.info("app.commitinterval=5<p>");
 			jobParams.put("execution.number", "1");
 			jobParams.put("readrecord.fail", "12");
 			jobParams.put("app.arraysize", "30");
 			jobParams.put("app.writepoints", "0,5,10,15,20,25,30");
 			jobParams.put("app.commitinterval", "5");
 
-			Reporter.log("Locate job XML file: chunksize5commitinterval5.xml<p>");
+			logger.info("Locate job XML file: chunksize5commitinterval5.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			TCKJobExecutionWrapper execution1 = jobOp.startJobAndWaitForResult("chunksize5commitinterval5", jobParams);
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
-			Reporter.log("execution #1 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
 			assertWithMessage("Testing execution #1", BatchStatus.FAILED, execution1.getBatchStatus());
 			assertWithMessage("Testing execution #1", "FAILED", execution1.getExitStatus());
 
 			long jobInstanceId = execution1.getInstanceId();
 			long lastExecutionId = execution1.getExecutionId();
-			Reporter.log("Got Job instance id: " + jobInstanceId + "<p>");
-			Reporter.log("Got Job execution id: " + lastExecutionId + "<p>");
+			logger.info("Got Job instance id: " + jobInstanceId + "<p>");
+			logger.info("Got Job execution id: " + lastExecutionId + "<p>");
 
 			boolean seenException = false;
 			try {
 				int countTrackerAFTER = jobOp.getJobInstanceCount("NoSuchJob");
 			} catch (NoSuchJobException noJobEx) {
-				Reporter.log("Confirmed we caught NoSuchJobException<p>");
+				logger.info("Confirmed we caught NoSuchJobException<p>");
 				seenException = true;
 			}
 			assertWithMessage("Saw NoSuchJobException for job 'NoSuchJob'", seenException);
@@ -728,7 +712,7 @@ public class JobOperatorTests {
 	 * 
 	 */
 	@Test  
-	@org.junit.Test
+
 	public void testJobOpgetJobInstances() throws Exception {
 		String METHOD = " testJobOpgetJobInstances";
 		begin(METHOD);
@@ -741,27 +725,27 @@ public class JobOperatorTests {
 
 			try {
 				countTrackerBEFORE = jobOp.getJobInstanceCount("chunksize5commitinterval5");
-				Reporter.log("Before test ran the JobInstance count for chunksize5commitinterval5 was " + countTrackerBEFORE +"<p>");
+				logger.info("Before test ran the JobInstance count for chunksize5commitinterval5 was " + countTrackerBEFORE +"<p>");
 			} catch (NoSuchJobException e) {
-				Reporter.log("Not an error, but just the first time executing this job <p>");
+				logger.info("Not an error, but just the first time executing this job <p>");
 			}
 
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
-			Reporter.log("execution.number=1<p>");
-			Reporter.log("readrecord.faile=12<p>");
-			Reporter.log("app.arraysize=30<p>");
-			Reporter.log("app.writepoints=0,5,10,15,20,25,30<p>");
-			Reporter.log("app.commitinterval=5<p>");
+			logger.info("execution.number=1<p>");
+			logger.info("readrecord.faile=12<p>");
+			logger.info("app.arraysize=30<p>");
+			logger.info("app.writepoints=0,5,10,15,20,25,30<p>");
+			logger.info("app.commitinterval=5<p>");
 			jobParams.put("execution.number", "1");
 			jobParams.put("readrecord.fail", "12");
 			jobParams.put("app.arraysize", "30");
 			jobParams.put("app.writepoints", "0,5,10,15,20,25,30");
 			jobParams.put("app.commitinterval", "5");
 
-			Reporter.log("Locate job XML file: chunksize5commitinterval5.xml<p>");
+			logger.info("Locate job XML file: chunksize5commitinterval5.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			for (int i=0; i < submitTimes; i++) {
 				jobOp.startJobWithoutWaitingForResult("chunksize5commitinterval5", jobParams);
 			}
@@ -773,11 +757,11 @@ public class JobOperatorTests {
 				assertWithMessage("Check that we see: " + submitTimes + " new submissions", 
 						submitTimes, countTrackerAFTER - countTrackerBEFORE);
 			} catch (NoSuchJobException noJobEx) {
-				Reporter.log("Failing test, caught NoSuchJobException<p>");
+				logger.info("Failing test, caught NoSuchJobException<p>");
 				throw noJobEx;
 			}
 
-			Reporter.log("Size of Job Instances list = " + jobInstances.size() + "<p>");
+			logger.info("Size of Job Instances list = " + jobInstances.size() + "<p>");
 			assertWithMessage("Testing that a list of Job Instances were obtained", 10, jobInstances.size());
 
 		} catch (Exception e) {
@@ -796,20 +780,20 @@ public class JobOperatorTests {
 	 * 
 	 */
 	@Test  
-	@org.junit.Test
+
 	public void testJobOpgetJobInstancesException() throws Exception {
 		String METHOD = "testJobOpgetJobInstancesException";
 		begin(METHOD);
 
 		try {
 
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
-			Reporter.log("execution.number=1<p>");
-			Reporter.log("readrecord.faile=12<p>");
-			Reporter.log("app.arraysize=30<p>");
-			Reporter.log("app.writepoints=0,5,10,15,20,25,30<p>");
-			Reporter.log("app.commitinterval=5<p>");
+			logger.info("execution.number=1<p>");
+			logger.info("readrecord.faile=12<p>");
+			logger.info("app.arraysize=30<p>");
+			logger.info("app.writepoints=0,5,10,15,20,25,30<p>");
+			logger.info("app.commitinterval=5<p>");
 			jobParams.put("execution.number", "1");
 			jobParams.put("readrecord.fail", "12");
 			jobParams.put("app.arraysize", "30");
@@ -817,13 +801,13 @@ public class JobOperatorTests {
 			jobParams.put("app.commitinterval", "5");
 
 
-			Reporter.log("Locate job XML file: /chunksize5commitinterval5.xml<p>");
+			logger.info("Locate job XML file: /chunksize5commitinterval5.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			TCKJobExecutionWrapper execution1 = jobOp.startJobAndWaitForResult("chunksize5commitinterval5", jobParams);
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
-			Reporter.log("execution #1 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
 			assertWithMessage("Testing execution #1", BatchStatus.FAILED, execution1.getBatchStatus());
 			assertWithMessage("Testing execution #1", "FAILED", execution1.getExitStatus());
 
@@ -833,7 +817,7 @@ public class JobOperatorTests {
 				jobIds = jobOp.getJobInstances("NoSuchJob", 0, 12);
 			} catch (NoSuchJobException noJobEx) {
 				seenException = true;
-				Reporter.log("Confirmed we caught NoSuchJobException<p>");
+				logger.info("Confirmed we caught NoSuchJobException<p>");
 			}
 			assertWithMessage("Saw NoSuchJobException for job 'NoSuchJob'", seenException);
 		} catch (Exception e) {
@@ -853,21 +837,21 @@ public class JobOperatorTests {
 	 * 
 	 */
 	@Test  
-	@org.junit.Test
+
 	public void testJobOperatorGetParameters() throws Exception {
 		String METHOD = "testJobOperatorGetParameters";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties originalJobParams = new Properties();
 			Properties restartJobParams = null;
-			Reporter.log("execution.number=1<p>");
-			Reporter.log("readrecord.fail=12<p>");
-			Reporter.log("app.arraysize=30<p>");
-			Reporter.log("app.writepoints=0,5,10,15,20,25,30<p>");
-			Reporter.log("app.next.writepoints=10,15,20,25,30<p>");
-			Reporter.log("app.commitinterval=5<p>");
+			logger.info("execution.number=1<p>");
+			logger.info("readrecord.fail=12<p>");
+			logger.info("app.arraysize=30<p>");
+			logger.info("app.writepoints=0,5,10,15,20,25,30<p>");
+			logger.info("app.next.writepoints=10,15,20,25,30<p>");
+			logger.info("app.commitinterval=5<p>");
 			originalJobParams.put("execution.number", "1");
 			originalJobParams.put("readrecord.fail", "12");
 			originalJobParams.put("app.arraysize", "30");
@@ -879,33 +863,33 @@ public class JobOperatorTests {
 			String N1="extra.parm.name1";  String V1="extra.parm.value1";
 			String N2="extra.parm.name2";  String V2="extra.parm.value2";
 
-			Reporter.log("Locate job XML file: chunksize5commitinterval5.xml<p>");
+			logger.info("Locate job XML file: chunksize5commitinterval5.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			TCKJobExecutionWrapper execution1 = jobOp.startJobAndWaitForResult("chunksize5commitinterval5", originalJobParams);
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
-			Reporter.log("execution #1 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
 			assertWithMessage("Testing execution #1", BatchStatus.FAILED, execution1.getBatchStatus());
 			assertWithMessage("Testing execution #1", "FAILED", execution1.getExitStatus());
 
 			long jobInstanceId = execution1.getInstanceId();
 			long lastExecutionId = execution1.getExecutionId();
 			TCKJobExecutionWrapper execution2 = null;
-			Reporter.log("Got Job instance id: " + jobInstanceId + "<p>");
-			Reporter.log("Got Job execution id: " + lastExecutionId + "<p>");
+			logger.info("Got Job instance id: " + jobInstanceId + "<p>");
+			logger.info("Got Job execution id: " + lastExecutionId + "<p>");
 			{
-				Reporter.log("Invoke clone original job execution parameters<p>");
+				logger.info("Invoke clone original job execution parameters<p>");
 				// Shallow copy is OK for simple <String,String> of java.util.Properties
 				restartJobParams = (Properties)originalJobParams.clone(); 
-				Reporter.log("Put some extra parms in the restart execution<p>");
+				logger.info("Put some extra parms in the restart execution<p>");
 				restartJobParams.put(N1, V1);
 				restartJobParams.put(N2, V2);
-				Reporter.log("Invoke restartJobAndWaitForResult for execution id: " + lastExecutionId + "<p>");
+				logger.info("Invoke restartJobAndWaitForResult for execution id: " + lastExecutionId + "<p>");
 				execution2 = jobOp.restartJobAndWaitForResult(lastExecutionId, restartJobParams);
-				Reporter.log("execution #2 JobExecution getBatchStatus()="+execution2.getBatchStatus()+"<p>");
-				Reporter.log("execution #2 JobExecution getExitStatus()="+execution2.getExitStatus()+"<p>");
-				Reporter.log("execution #2 Job instance id="+execution2.getInstanceId()+"<p>");
+				logger.info("execution #2 JobExecution getBatchStatus()="+execution2.getBatchStatus()+"<p>");
+				logger.info("execution #2 JobExecution getExitStatus()="+execution2.getExitStatus()+"<p>");
+				logger.info("execution #2 Job instance id="+execution2.getInstanceId()+"<p>");
 				assertWithMessage("Testing execution #2", BatchStatus.COMPLETED, execution2.getBatchStatus());
 				assertWithMessage("Testing execution #2", "COMPLETED", execution2.getExitStatus());
 				assertWithMessage("Testing execution #2", jobInstanceId, execution2.getInstanceId());  
@@ -915,17 +899,17 @@ public class JobOperatorTests {
 			Properties jobParamsFromJobOperator = jobOp.getParameters(execution1.getExecutionId());
 			Properties jobParamsFromJobExecution = execution1.getJobParameters();
   			assertWithMessage("Comparing original job params with jobOperator.getParameters", originalJobParams, jobParamsFromJobOperator);
-			Reporter.log("JobOperator.getParameters() matches for original execution <p>");
+			logger.info("JobOperator.getParameters() matches for original execution <p>");
 			assertWithMessage("Comparing original job params with jobExecution.getParameters", originalJobParams, jobParamsFromJobExecution);
-			Reporter.log("JobExecution.getParameters() matches for original execution <p>");
+			logger.info("JobExecution.getParameters() matches for original execution <p>");
 			
 			// Test restart execution
 			Properties restartJobParamsFromJobOperator = jobOp.getParameters(execution2.getExecutionId());
 			Properties restartJobParamsFromJobExecution = execution2.getJobParameters();
 			assertWithMessage("Comparing restart job params with jobOperator.getParameters", restartJobParams, restartJobParamsFromJobOperator);
-			Reporter.log("JobOperator.getParameters() matches for restart execution <p>");
+			logger.info("JobOperator.getParameters() matches for restart execution <p>");
 			assertWithMessage("Comparing restart job params with jobExecution.getParameters", restartJobParams, restartJobParamsFromJobExecution);
-			Reporter.log("JobExecution.getParameters() matches for restart execution <p>");
+			logger.info("JobExecution.getParameters() matches for restart execution <p>");
 			
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -945,66 +929,66 @@ public class JobOperatorTests {
 	 * 
 	 */
 	@Test  
-	@org.junit.Test
+
 	public void testJobOperatorGetJobInstances() throws Exception {
 		String METHOD = "testJobOperatorGetJobInstances";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
-			Reporter.log("execution.number=1<p>");
-			Reporter.log("readrecord.fail=31<p>");
-			Reporter.log("app.arraysize=30<p>");
-			Reporter.log("app.writepoints=0,5,10,15,20,25,30<p>");
-			Reporter.log("app.commitinterval=5<p>");
+			logger.info("execution.number=1<p>");
+			logger.info("readrecord.fail=31<p>");
+			logger.info("app.arraysize=30<p>");
+			logger.info("app.writepoints=0,5,10,15,20,25,30<p>");
+			logger.info("app.commitinterval=5<p>");
 			jobParams.put("execution.number", "1");
 			jobParams.put("readrecord.fail", "31");
 			jobParams.put("app.arraysize", "30");
 			jobParams.put("app.writepoints", "0,5,10,15,20,25,30");
 			jobParams.put("app.commitinterval", "5");
 
-			Reporter.log("Locate job XML file: chunksize5commitinterval5.xml<p>");
+			logger.info("Locate job XML file: chunksize5commitinterval5.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			JobExecution execution1 = jobOp.startJobAndWaitForResult("chunksize5commitinterval5", jobParams);
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
-			Reporter.log("execution #1 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
 			assertWithMessage("Testing execution #1", BatchStatus.COMPLETED, execution1.getBatchStatus());
 			assertWithMessage("Testing execution #1", "COMPLETED", execution1.getExitStatus());
 
-			Reporter.log("Create job parameters for execution #2:<p>");
+			logger.info("Create job parameters for execution #2:<p>");
 			jobParams = new Properties();
-			Reporter.log("execution.number=2<p>");
-			Reporter.log("readrecord.fail=31<p>");
-			Reporter.log("app.arraysize=30<p>");
-			Reporter.log("app.writepoints=10,15,20,25,30<p>");
-			Reporter.log("app.commitinterval=5<p>");
+			logger.info("execution.number=2<p>");
+			logger.info("readrecord.fail=31<p>");
+			logger.info("app.arraysize=30<p>");
+			logger.info("app.writepoints=10,15,20,25,30<p>");
+			logger.info("app.commitinterval=5<p>");
 			jobParams.put("execution.number", "1");
 			jobParams.put("readrecord.fail", "31");
 			jobParams.put("app.arraysize", "30");
 			jobParams.put("app.writepoints", "0,5,10,15,20,25,30");
 			jobParams.put("app.commitinterval", "5");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #2<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #2<p>");
 			JobExecution execution2 = jobOp.startJobAndWaitForResult("chunksize5commitinterval5", jobParams);
-			Reporter.log("execution #2 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
-			Reporter.log("execution #2 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
+			logger.info("execution #2 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
+			logger.info("execution #2 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
 			assertWithMessage("Testing execution #2", BatchStatus.COMPLETED, execution2.getBatchStatus());
 			assertWithMessage("Testing execution #2", "COMPLETED", execution2.getExitStatus());
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #3<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #3<p>");
 			JobExecution execution3 = jobOp.startJobAndWaitForResult("chunksize5commitinterval5", jobParams);
-			Reporter.log("execution #3 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
-			Reporter.log("execution #3 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
+			logger.info("execution #3 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
+			logger.info("execution #3 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
 			assertWithMessage("Testing execution #3", BatchStatus.COMPLETED, execution3.getBatchStatus());
 			assertWithMessage("Testing execution #3", "COMPLETED", execution3.getExitStatus());
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #4<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #4<p>");
 			JobExecution execution4 = jobOp.startJobAndWaitForResult("chunksize5commitinterval5", jobParams);
-			Reporter.log("execution #4 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
-			Reporter.log("execution #4 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
+			logger.info("execution #4 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
+			logger.info("execution #4 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
 			assertWithMessage("Testing execution #4", BatchStatus.COMPLETED, execution4.getBatchStatus());
 			assertWithMessage("Testing execution #4", "COMPLETED", execution4.getExitStatus());
 
@@ -1021,8 +1005,8 @@ public class JobOperatorTests {
 			assertWithMessage("job instances should be equal", jobInstances012.get(2).getInstanceId()==jobInstances123.get(1).getInstanceId()); 
 			assertWithMessage("job instances should not be equal", jobInstances012.get(2).getInstanceId()!=jobInstances123.get(2).getInstanceId()); 
 
-			Reporter.log("Size of jobInstancesList = " + jobInstances012.size() + "<p>");
-			Reporter.log("Testing retrieval of the JobInstances list, size = " + jobInstances012.size() + "<p>");
+			logger.info("Size of jobInstancesList = " + jobInstances012.size() + "<p>");
+			logger.info("Testing retrieval of the JobInstances list, size = " + jobInstances012.size() + "<p>");
 			assertWithMessage("Testing retrieval of the JobInstances list", jobInstances012.size() > 0);
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -1041,7 +1025,7 @@ public class JobOperatorTests {
 	 * 
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testJobOperatorGetRunningJobExecutions() throws Exception {
 		String METHOD = "testJobOperatorGetRunningJobExecutions";
 		begin(METHOD);
@@ -1050,25 +1034,25 @@ public class JobOperatorTests {
 		final String DEFAULT_APP_TIME_INTERVAL = "10000";
 
 		try {
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
 			String timeinterval = System.getProperty("JobOperatorTests.testJobOperatorGetRunningJobExecutions.app.timeinterval",DEFAULT_APP_TIME_INTERVAL);
 			
 			jobParams.put("app.timeinterval", timeinterval);
 
-			Reporter.log("Invoke startJobWithoutWaitingForResult for execution #1<p>");
+			logger.info("Invoke startJobWithoutWaitingForResult for execution #1<p>");
 			JobExecution execution1 = jobOp.startJobWithoutWaitingForResult("job_batchlet_step_listener", jobParams);
 
 			Properties newJobParameters = new Properties();
 			newJobParameters.put("app.timeinterval", timeinterval);
-			Reporter.log("Invoke startJobWithoutWaitingForResult<p>");
+			logger.info("Invoke startJobWithoutWaitingForResult<p>");
 
 			JobExecution exec = jobOp.startJobWithoutWaitingForResult("job_batchlet_step_listener", newJobParameters);
 
 			// Sleep to give the runtime the chance to start the job.  The job has a delay built into the stepListener afterStep() 
 			// so we aren't worried about the job finishing early leaving zero running executions.
 			int sleepTime = Integer.parseInt(System.getProperty("ExecutionTests.testJobOperatorGetRunningJobExecutions.sleep",DEFAULT_SLEEP_TIME));
-			Reporter.log("Thread.sleep(" + sleepTime + ")<p>");
+			logger.info("Thread.sleep(" + sleepTime + ")<p>");
 			Thread.sleep(sleepTime);
 
 			List<Long> jobExecutions = jobOp.getRunningExecutions("job_batchlet_step_listener");
@@ -1091,7 +1075,7 @@ public class JobOperatorTests {
 	 * 
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testJobOperatorGetRunningJobInstancesException() throws Exception {
 		String METHOD = "testJobOperatorGetRunningJobInstancesException";
 		begin(METHOD);
@@ -1099,29 +1083,29 @@ public class JobOperatorTests {
 		final String DEFAULT_APP_TIME_INTERVAL = "10000";
 
 		try {
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
 		
 			String timeinterval = System.getProperty("JobOperatorTests.testJobOperatorGetRunningJobInstancesException.app.timeinterval",DEFAULT_APP_TIME_INTERVAL);
 			
 			jobParams.put("app.timeinterval", timeinterval);
 
-			Reporter.log("Invoke startJobWithoutWaitingForResult for execution #1<p>");
+			logger.info("Invoke startJobWithoutWaitingForResult for execution #1<p>");
 			JobExecution execution1 = jobOp.startJobWithoutWaitingForResult("job_batchlet_step_listener", jobParams);
 
 			Properties restartJobParameters = new Properties();
 			restartJobParameters.put("app.timeinterval", timeinterval);
 
-			Reporter.log("Invoke startJobWithoutWaitingForResult");
+			logger.info("Invoke startJobWithoutWaitingForResult");
 			JobExecution exec = jobOp.startJobWithoutWaitingForResult("job_batchlet_step_listener", restartJobParameters);
 
 			boolean seenException = false;
 			try {
-				Reporter.log("Check for an instance of a non-existent job<p>");
+				logger.info("Check for an instance of a non-existent job<p>");
 				jobOp.getRunningExecutions("JOBNAMEDOESNOTEXIST");
 			}
 			catch (NoSuchJobException e) {
-				Reporter.log("Confirmed that exception caught is an instanceof NoSuchJobException<p>");
+				logger.info("Confirmed that exception caught is an instanceof NoSuchJobException<p>");
 				seenException = true;
 			}
 			assertWithMessage("Saw NoSuchJobException for job 'JOBNAMEDOESNOTEXIST'", seenException);
@@ -1142,20 +1126,20 @@ public class JobOperatorTests {
 	 * 
 	 */
 	@Test 
-	@org.junit.Test
+
 	public void testJobOperatorGetJobExecution() throws Exception {
 		String METHOD = "testJobOperatorGetJobExecution";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
-			Reporter.log("execution.number=1<p>");
-			Reporter.log("readrecord.fail=12<p>");
-			Reporter.log("app.arraysize=30<p>");
-			Reporter.log("app.writepoints=0,5,10,15,20,25,30<p>");
-			Reporter.log("app.next.writepoints=10,15,20,25,30<p>");
-			Reporter.log("app.commitinterval=5<p>");
+			logger.info("execution.number=1<p>");
+			logger.info("readrecord.fail=12<p>");
+			logger.info("app.arraysize=30<p>");
+			logger.info("app.writepoints=0,5,10,15,20,25,30<p>");
+			logger.info("app.next.writepoints=10,15,20,25,30<p>");
+			logger.info("app.commitinterval=5<p>");
 			jobParams.put("execution.number", "1");
 			jobParams.put("readrecord.fail", "12");
 			jobParams.put("app.arraysize", "30");
@@ -1163,13 +1147,13 @@ public class JobOperatorTests {
 			jobParams.put("app.next.writepoints", "10,15,20,25,30");
 			jobParams.put("app.commitinterval", "5");
 
-			Reporter.log("Locate job XML file: chunksize5commitinterval5.xml<p>");
+			logger.info("Locate job XML file: chunksize5commitinterval5.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			TCKJobExecutionWrapper execution1 = jobOp.startJobAndWaitForResult("chunksize5commitinterval5", jobParams);
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
-			Reporter.log("execution #1 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
 			assertWithMessage("Testing execution #1", BatchStatus.FAILED, execution1.getBatchStatus());
 			assertWithMessage("Testing execution #1", "FAILED", execution1.getExitStatus());
 
@@ -1179,20 +1163,20 @@ public class JobOperatorTests {
 
 			{
 
-				Reporter.log("Invoke restartJobAndWaitForResult for execution id: " + lastExecutionId + "<p>");
+				logger.info("Invoke restartJobAndWaitForResult for execution id: " + lastExecutionId + "<p>");
 				exec = jobOp.restartJobAndWaitForResult(lastExecutionId, jobParams);
 				lastExecutionId = exec.getExecutionId();
-				Reporter.log("execution #2 JobExecution getBatchStatus()="+exec.getBatchStatus()+"<p>");
-				Reporter.log("execution #2 JobExecution getExitStatus()="+exec.getExitStatus()+"<p>");
-				Reporter.log("execution #2 Job instance id="+exec.getInstanceId()+"<p>");
+				logger.info("execution #2 JobExecution getBatchStatus()="+exec.getBatchStatus()+"<p>");
+				logger.info("execution #2 JobExecution getExitStatus()="+exec.getExitStatus()+"<p>");
+				logger.info("execution #2 Job instance id="+exec.getInstanceId()+"<p>");
 				assertWithMessage("Testing execution #2", BatchStatus.COMPLETED, exec.getBatchStatus());
 				assertWithMessage("Testing execution #2", "COMPLETED", exec.getExitStatus());
 				assertWithMessage("Testing execution #2", jobInstanceId, exec.getInstanceId());  
 			}
 
-			Reporter.log("Testing retrieval of a JobExecution obj");
+			logger.info("Testing retrieval of a JobExecution obj");
 			JobExecution jobEx = jobOp.getJobExecution(lastExecutionId);
-			Reporter.log("Status retreived from JobExecution obj: " + jobEx.getBatchStatus() + "<p>");
+			logger.info("Status retreived from JobExecution obj: " + jobEx.getBatchStatus() + "<p>");
 		} catch (Exception e) {
 			handleException(METHOD, e);
 		}
@@ -1211,14 +1195,14 @@ public class JobOperatorTests {
 	 * 
 	 */
 	@Test 
-	@org.junit.Test
+
 	public void testJobOperatorGetJobExecutions() throws Exception {
 		String METHOD = "testJobOperatorGetJobExecutions";
 		begin(METHOD);
 
 		String jobName = "chunksize5commitinterval5";
 		try {
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
 			jobParams.put("execution.number", "1");
 			jobParams.put("readrecord.fail", "12");
@@ -1227,13 +1211,13 @@ public class JobOperatorTests {
 			jobParams.put("app.next.writepoints", "10,15,20,25,30");
 			jobParams.put("app.commitinterval", "5");
 
-			Reporter.log("Locate job XML file: chunksize5commitinterval5.xml<p>");
+			logger.info("Locate job XML file: chunksize5commitinterval5.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			TCKJobExecutionWrapper execution1 = jobOp.startJobAndWaitForResult(jobName, jobParams);
 		    
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
-			Reporter.log("execution #1 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+execution1.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getExitStatus()="+execution1.getExitStatus()+"<p>");
 			assertWithMessage("Testing execution #1", BatchStatus.FAILED, execution1.getBatchStatus());
 			assertWithMessage("Testing execution #1", "FAILED", execution1.getExitStatus());
 
@@ -1241,11 +1225,11 @@ public class JobOperatorTests {
 			TCKJobExecutionWrapper execution2 = null;
 
 			{
-				Reporter.log("Invoke restartJobAndWaitForResult for execution id: " + execution1ID + "<p>");
+				logger.info("Invoke restartJobAndWaitForResult for execution id: " + execution1ID + "<p>");
 				execution2= jobOp.restartJobAndWaitForResult(execution1ID, jobParams);
-				Reporter.log("execution #2 JobExecution getBatchStatus()="+execution2.getBatchStatus()+"<p>");
-				Reporter.log("execution #2 JobExecution getExitStatus()="+execution2.getExitStatus()+"<p>");
-				Reporter.log("execution #2 Job instance id="+execution2.getInstanceId()+"<p>");
+				logger.info("execution #2 JobExecution getBatchStatus()="+execution2.getBatchStatus()+"<p>");
+				logger.info("execution #2 JobExecution getExitStatus()="+execution2.getExitStatus()+"<p>");
+				logger.info("execution #2 Job instance id="+execution2.getInstanceId()+"<p>");
 				assertWithMessage("Testing execution #2", BatchStatus.COMPLETED, execution2.getBatchStatus());
 				assertWithMessage("Testing execution #2", "COMPLETED", execution2.getExitStatus());
 			}
@@ -1264,11 +1248,11 @@ public class JobOperatorTests {
 			for (JobExecution je : jobExecutions){
 				if (je.getExecutionId() == execution1ID) {
 					assertWithMessage("Dup of execution 1", !seen1);
-					Reporter.log("Seen execution #1 <p>");
+					logger.info("Seen execution #1 <p>");
 					seen1= true;
 				} else if (je.getExecutionId() == execution2ID) {
 					assertWithMessage("Dup of execution 2", !seen2);
-					Reporter.log("Seen execution #2 <p>");
+					logger.info("Seen execution #2 <p>");
 					seen2= true;
 				} 
 			}
@@ -1286,21 +1270,21 @@ public class JobOperatorTests {
 	private void showStepState(StepExecution step) {
 
 
-		Reporter.log("---------------------------");
-		Reporter.log("getStepName(): " + step.getStepName() + " - ");
-		Reporter.log("getJobExecutionId(): " + step.getStepExecutionId() + " - ");
+		logger.info("---------------------------");
+		logger.info("getStepName(): " + step.getStepName() + " - ");
+		logger.info("getJobExecutionId(): " + step.getStepExecutionId() + " - ");
 		//System.out.print("getStepExecutionId(): " + step.getStepExecutionId() + " - ");
 		Metric[] metrics = step.getMetrics();
 
 		for (int i = 0; i < metrics.length; i++) {
-			Reporter.log(metrics[i].getType() + ": " + metrics[i].getValue() + " - ");
+			logger.info(metrics[i].getType() + ": " + metrics[i].getValue() + " - ");
 		}
 
-		Reporter.log("getStartTime(): " + step.getStartTime() + " - ");
-		Reporter.log("getEndTime(): " + step.getEndTime() + " - ");
+		logger.info("getStartTime(): " + step.getStartTime() + " - ");
+		logger.info("getEndTime(): " + step.getEndTime() + " - ");
 		//System.out.print("getLastUpdateTime(): " + step.getLastUpdateTime() + " - ");
-		Reporter.log("getBatchStatus(): " + step.getBatchStatus() + " - ");
-		Reporter.log("getExitStatus(): " + step.getExitStatus());
-		Reporter.log("---------------------------");
+		logger.info("getBatchStatus(): " + step.getBatchStatus() + " - ");
+		logger.info("getExitStatus(): " + step.getExitStatus());
+		logger.info("---------------------------");
 	}
 }

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ListenerOnErrorTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ListenerOnErrorTests.java
@@ -25,21 +25,18 @@ import java.util.Properties;
 import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.JobExecution;
 
-import org.junit.BeforeClass;
-import org.testng.Reporter;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
 import com.ibm.jbatch.tck.ann.*;
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.*;
 
 
 public class ListenerOnErrorTests {
-	private static JobOperatorBridge jobOp = null;
+	private static final Logger logger = Logger.getLogger(ListenerOnErrorTests.class.getName());
+	private JobOperatorBridge jobOp = null;
 	
-	@BeforeMethod
-	@BeforeClass
-	public static void setup() throws Exception {
+	@BeforeEach
+	public void setup() throws Exception {
 		jobOp = new JobOperatorBridge();
 	}
 
@@ -68,21 +65,21 @@ public class ListenerOnErrorTests {
 				+ "based on the chunk size, input data, and failing record number. Also check that the job fails."
 	)
 	@Test
-	@org.junit.Test
+
 	public void testOnWriteErrorItems() throws Exception {
 		String GOOD_EXIT_STATUS = new String("[10, 12, 14, 16, 18]");
 		
-	    Reporter.log("Create job parameters for execution<p>");
+	    logger.info("Create job parameters for execution<p>");
         Properties jobParams = new Properties();
 		
-	    Reporter.log("write.fail=true<p>");
+	    logger.info("write.fail=true<p>");
 	    jobParams.put("write.fail", "true");
 
-	    Reporter.log("Invoke startJobAndWaitForResult for execution<p>");
+	    logger.info("Invoke startJobAndWaitForResult for execution<p>");
 	    JobExecution je = jobOp.startJobAndWaitForResult("listenerOnError", jobParams);
 	
-	    Reporter.log("JobExecution getBatchStatus()=" + je.getBatchStatus() + "<p>");
-	    Reporter.log("JobExecution getExitStatus()=" + je.getExitStatus() + "<p>");
+	    logger.info("JobExecution getBatchStatus()=" + je.getBatchStatus() + "<p>");
+	    logger.info("JobExecution getExitStatus()=" + je.getExitStatus() + "<p>");
 	    assertWithMessage("Testing execution for the WRITE LISTENER", BatchStatus.FAILED, je.getBatchStatus());
 	    assertWithMessage("Testing execution for the WRITE LISTENER", GOOD_EXIT_STATUS, je.getExitStatus());
 	}
@@ -112,20 +109,20 @@ public class ListenerOnErrorTests {
     			+ "based on the input data and the failing record number. Also check that the job fails."    	
     )
 	@Test
-	@org.junit.Test
+
 	public void testOnProcessErrorItems() throws Exception {
 		String GOOD_EXIT_STATUS = new String("8");
-        Reporter.log("Create job parameters for execution:<p>");
+        logger.info("Create job parameters for execution:<p>");
         Properties jobParams = new Properties();
 
-        Reporter.log("process.fail=true<p>");
+        logger.info("process.fail=true<p>");
         jobParams.put("process.fail", "true");
 
-        Reporter.log("Invoke startJobAndWaitForResult for execution<p>");
+        logger.info("Invoke startJobAndWaitForResult for execution<p>");
         JobExecution je = jobOp.startJobAndWaitForResult("listenerOnError", jobParams);
 
-        Reporter.log("JobExecution getBatchStatus()=" + je.getBatchStatus() + "<p>");
-        Reporter.log("JobExecution getExitStatus()=" + je.getExitStatus() + "<p>");
+        logger.info("JobExecution getBatchStatus()=" + je.getBatchStatus() + "<p>");
+        logger.info("JobExecution getExitStatus()=" + je.getExitStatus() + "<p>");
         assertWithMessage("Testing execution for the PROCESS LISTENER", BatchStatus.FAILED, je.getBatchStatus());
         assertWithMessage("Testing execution for the PROCESS LISTENER", GOOD_EXIT_STATUS, je.getExitStatus());
 	}

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/MetricsTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/MetricsTests.java
@@ -29,31 +29,17 @@ import javax.batch.runtime.JobExecution;
 import javax.batch.runtime.Metric;
 import javax.batch.runtime.StepExecution;
 
-import org.junit.BeforeClass;
-import org.testng.Reporter;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
 import com.ibm.jbatch.tck.artifacts.specialized.MetricsStepListener;
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.*;
 
 public class MetricsTests {
+	private static final Logger logger = Logger.getLogger(MetricsTests.class.getName());
+	private JobOperatorBridge jobOp = null;
 
-	private static JobOperatorBridge jobOp = null;
-
-	public static void setup(String[] args, Properties props) throws Exception {
-		String METHOD = "setup";
-
-		try {
-			jobOp = new JobOperatorBridge();
-		} catch (Exception e) {
-			handleException(METHOD, e);
-		}
-	}
-
-	@BeforeMethod
-	@BeforeClass
-	public static void setUp() throws Exception {
+	@BeforeEach
+	public void setUp() throws Exception {
 		jobOp = new JobOperatorBridge();
 	}
 
@@ -79,20 +65,20 @@ public class MetricsTests {
 	 * 
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testMetricsInApp() throws Exception {
 		String METHOD = "testMetricsInApp";
 
 		try {
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
-			Reporter.log("execution.number=1<p>");
-			Reporter.log("readrecord.fail=40<p>");
-			Reporter.log("app.arraysize=30<p>");
-			Reporter.log("app.chunksize=7<p>");
-			Reporter.log("app.commitinterval=10<p>");
-			Reporter.log("numberOfSkips=0<p>");
-			Reporter.log("ReadProcessWrite=READ<p>");
+			logger.info("execution.number=1<p>");
+			logger.info("readrecord.fail=40<p>");
+			logger.info("app.arraysize=30<p>");
+			logger.info("app.chunksize=7<p>");
+			logger.info("app.commitinterval=10<p>");
+			logger.info("numberOfSkips=0<p>");
+			logger.info("ReadProcessWrite=READ<p>");
 			jobParams.put("execution.number", "1");
 			jobParams.put("readrecord.fail", "40");
 			jobParams.put("app.arraysize", "30");
@@ -103,14 +89,14 @@ public class MetricsTests {
 			jobParams.put("app.writepoints", "0,7,14,21,28,30");
 			jobParams.put("app.next.writepoints", "7,14,21,28,30");
 
-			Reporter.log("Locate job XML file: testChunkMetrics.xml<p>");
+			logger.info("Locate job XML file: testChunkMetrics.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			JobExecution execution1 = jobOp.startJobAndWaitForResult("testChunkMetrics",
 					jobParams);
-			Reporter.log("execution #1 JobExecution getBatchStatus()="
+			logger.info("execution #1 JobExecution getBatchStatus()="
 					+ execution1.getBatchStatus() + "<p>");
-			Reporter.log("execution #1 JobExecution getExitStatus()="
+			logger.info("execution #1 JobExecution getExitStatus()="
 					+ execution1.getExitStatus() + "<p>");
 			assertWithMessage("Testing execution #1", BatchStatus.COMPLETED,
 					execution1.getBatchStatus());
@@ -130,34 +116,34 @@ public class MetricsTests {
 	 * 
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testMetricsSkipRead() throws Exception {
 
 		String METHOD = "testMetricsSkipRead";
 
 		try {
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
-			Reporter.log("execution.number=1<p>");
-			Reporter.log("readrecord.fail=1,3<p>");
-			Reporter.log("app.arraysize=30<p>");
-			Reporter.log("numberOfSkips=2<p>");
-			Reporter.log("ReadProcessWrite=READ_SKIP<p>");
+			logger.info("execution.number=1<p>");
+			logger.info("readrecord.fail=1,3<p>");
+			logger.info("app.arraysize=30<p>");
+			logger.info("numberOfSkips=2<p>");
+			logger.info("ReadProcessWrite=READ_SKIP<p>");
 			jobParams.put("execution.number", "1");
 			jobParams.put("readrecord.fail", "1,3,4,12");
 			jobParams.put("app.arraysize", "30");
 			jobParams.put("numberOfSkips", "4");
 			jobParams.put("ReadProcessWrite", "READ_SKIP");
 
-			Reporter.log("Locate job XML file: testMetricsSkipCount.xml<p>");
+			logger.info("Locate job XML file: testMetricsSkipCount.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			JobExecution execution1 = jobOp.startJobAndWaitForResult("testMetricsSkipCount",
 					jobParams);
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="
+			logger.info("execution #1 JobExecution getBatchStatus()="
 					+ execution1.getBatchStatus() + "<p>");
-			Reporter.log("execution #1 JobExecution getExitStatus()="
+			logger.info("execution #1 JobExecution getExitStatus()="
 					+ execution1.getExitStatus() + "<p>");
 			assertWithMessage("Testing execution #1", BatchStatus.COMPLETED,
 					execution1.getBatchStatus());
@@ -177,17 +163,17 @@ public class MetricsTests {
 				}
 			}
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="
+			logger.info("execution #1 JobExecution getBatchStatus()="
 					+ execution1.getBatchStatus() + "<p>");
 			assertWithMessage("Testing execution #1", BatchStatus.COMPLETED,
 					execution1.getBatchStatus());
 
 			Metric[] metrics = step.getMetrics();
 
-			Reporter.log("Testing the read count for execution #1<p>");
+			logger.info("Testing the read count for execution #1<p>");
 			for (int i = 0; i < metrics.length; i++) {
 				if (metrics[i].getType().equals(Metric.MetricType.READ_SKIP_COUNT)) {
-					Reporter.log("AJM: in test, found metric: " + metrics[i].getType() + "<p>");
+					logger.info("AJM: in test, found metric: " + metrics[i].getType() + "<p>");
 					assertWithMessage(
 							"Testing the read skip count for execution #1", 4L,
 							metrics[i].getValue());
@@ -207,34 +193,34 @@ public class MetricsTests {
 	 * 
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testMetricsSkipWrite() throws Exception {
 
 		String METHOD = "testMetricsSkipWrite";
 
 		try {
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
-			Reporter.log("execution.number=1<p>");
-			Reporter.log("readrecord.fail=1,3<p>");
-			Reporter.log("app.arraysize=30<p>");
-			Reporter.log("numberOfSkips=2<p>");
-			Reporter.log("ReadProcessWrite=WRITE_SKIP<p>");
+			logger.info("execution.number=1<p>");
+			logger.info("readrecord.fail=1,3<p>");
+			logger.info("app.arraysize=30<p>");
+			logger.info("numberOfSkips=2<p>");
+			logger.info("ReadProcessWrite=WRITE_SKIP<p>");
 			jobParams.put("execution.number", "1");
 			jobParams.put("writerecord.fail", "1,3,4");
 			jobParams.put("app.arraysize", "30");
 			jobParams.put("numberOfSkips", "3");
 			jobParams.put("ReadProcessWrite", "WRITE_SKIP");
 
-			Reporter.log("Locate job XML file: testMetricsSkipWriteCount.xml<p>");
+			logger.info("Locate job XML file: testMetricsSkipWriteCount.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			JobExecution execution1 = jobOp.startJobAndWaitForResult("testMetricsSkipWriteCount",
 					jobParams);
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="
+			logger.info("execution #1 JobExecution getBatchStatus()="
 					+ execution1.getBatchStatus() + "<p>");
-			Reporter.log("execution #1 JobExecution getExitStatus()="
+			logger.info("execution #1 JobExecution getExitStatus()="
 					+ execution1.getExitStatus() + "<p>");
 			assertWithMessage("Testing execution #1", BatchStatus.COMPLETED,
 					execution1.getBatchStatus());
@@ -251,17 +237,17 @@ public class MetricsTests {
 				}
 			}
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="
+			logger.info("execution #1 JobExecution getBatchStatus()="
 					+ execution1.getBatchStatus() + "<p>");
 			assertWithMessage("Testing execution #1", BatchStatus.COMPLETED,
 					execution1.getBatchStatus());
 
 			Metric[] metrics = step.getMetrics();
 
-			Reporter.log("Testing the write skip count for execution #1<p>");
+			logger.info("Testing the write skip count for execution #1<p>");
 			for (int i = 0; i < metrics.length; i++) {
 				if (metrics[i].getType().equals(Metric.MetricType.WRITE_SKIP_COUNT)) {
-					Reporter.log("AJM: in test, found metric: " + metrics[i].getType() + "<p>");
+					logger.info("AJM: in test, found metric: " + metrics[i].getType() + "<p>");
 					assertWithMessage(
 							"Testing the write skip count for execution #1", 3L,
 							metrics[i].getValue());
@@ -281,33 +267,33 @@ public class MetricsTests {
 	 * 
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testMetricsSkipProcess() throws Exception {
 		String METHOD = "testMetricsSkipProcess";
 
 		try {
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
-			Reporter.log("execution.number=1<p>");
-			Reporter.log("readrecord.fail=7,13<p>");
-			Reporter.log("app.arraysize=30<p>");
-			Reporter.log("numberOfSkips=2<p>");
-			Reporter.log("ReadProcessWrite=PROCESS<p>");
+			logger.info("execution.number=1<p>");
+			logger.info("readrecord.fail=7,13<p>");
+			logger.info("app.arraysize=30<p>");
+			logger.info("numberOfSkips=2<p>");
+			logger.info("ReadProcessWrite=PROCESS<p>");
 			jobParams.put("execution.number", "1");
 			jobParams.put("processrecord.fail", "7,13");
 			jobParams.put("app.arraysize", "30");
 			jobParams.put("numberOfSkips", "2");
 			jobParams.put("ReadProcessWrite", "PROCESS");
 
-			Reporter.log("Locate job XML file: testMetricsSkipCount.xml<p>");
+			logger.info("Locate job XML file: testMetricsSkipCount.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			JobExecution execution1 = jobOp.startJobAndWaitForResult("testMetricsSkipCount",
 					jobParams);
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="
+			logger.info("execution #1 JobExecution getBatchStatus()="
 					+ execution1.getBatchStatus() + "<p>");
-			Reporter.log("execution #1 JobExecution getExitStatus()="
+			logger.info("execution #1 JobExecution getExitStatus()="
 					+ execution1.getExitStatus() + "<p>");
 			assertWithMessage("Testing execution #1", BatchStatus.COMPLETED,
 					execution1.getBatchStatus());
@@ -327,17 +313,17 @@ public class MetricsTests {
 				}
 			}
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="
+			logger.info("execution #1 JobExecution getBatchStatus()="
 					+ execution1.getBatchStatus() + "<p>");
 			assertWithMessage("Testing execution #1", BatchStatus.COMPLETED,
 					execution1.getBatchStatus());
 
 			Metric[] metrics = step.getMetrics();
 
-			Reporter.log("Testing the read count for execution #1<p>");
+			logger.info("Testing the read count for execution #1<p>");
 			for (int i = 0; i < metrics.length; i++) {
 				if (metrics[i].getType().equals(Metric.MetricType.PROCESS_SKIP_COUNT)) {
-					Reporter.log("AJM: in test, found metric: " + metrics[i].getType() + "<p>");
+					logger.info("AJM: in test, found metric: " + metrics[i].getType() + "<p>");
 					assertWithMessage(
 							"Testing the read count for execution #1", 2L,
 							metrics[i].getValue());
@@ -356,32 +342,32 @@ public class MetricsTests {
 	 * 
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testReadMetric() throws Exception {
 		String METHOD = "testReadMetric";
 
 		try {
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
-			Reporter.log("execution.number=1<p>");
-			Reporter.log("readrecord.fail=40<p>");
-			Reporter.log("app.arraysize=30<p>");
-			Reporter.log("app.chunksize=7<p>");
-			Reporter.log("app.commitinterval=10<p>");
-			Reporter.log("numberOfSkips=0<p>");
-			Reporter.log("ReadProcessWrite=READ<p>");
+			logger.info("execution.number=1<p>");
+			logger.info("readrecord.fail=40<p>");
+			logger.info("app.arraysize=30<p>");
+			logger.info("app.chunksize=7<p>");
+			logger.info("app.commitinterval=10<p>");
+			logger.info("numberOfSkips=0<p>");
+			logger.info("ReadProcessWrite=READ<p>");
 			jobParams.put("execution.number", "1");
 			jobParams.put("readrecord.fail", "-1");
 			jobParams.put("app.arraysize", "30");
 
-			Reporter.log("Locate job XML file: testChunkMetrics.xml<p>");
+			logger.info("Locate job XML file: testChunkMetrics.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			JobExecution execution1 = jobOp.startJobAndWaitForResult("testMetricCount",
 					jobParams);
-			Reporter.log("execution #1 JobExecution getBatchStatus()="
+			logger.info("execution #1 JobExecution getBatchStatus()="
 					+ execution1.getBatchStatus() + "<p>");
-			Reporter.log("execution #1 JobExecution getExitStatus()="
+			logger.info("execution #1 JobExecution getExitStatus()="
 					+ execution1.getExitStatus() + "<p>");
 
 			List<StepExecution> stepExecutions = jobOp
@@ -396,17 +382,17 @@ public class MetricsTests {
 				}
 			}
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="
+			logger.info("execution #1 JobExecution getBatchStatus()="
 					+ execution1.getBatchStatus() + "<p>");
 			assertWithMessage("Testing execution #1", BatchStatus.COMPLETED,
 					execution1.getBatchStatus());
 
 			Metric[] metrics = step.getMetrics();
 
-			Reporter.log("Testing the read count for execution #1<p>");
+			logger.info("Testing the read count for execution #1<p>");
 			for (int i = 0; i < metrics.length; i++) {
 				if (metrics[i].getType().equals(Metric.MetricType.READ_COUNT)) {
-					Reporter.log("AJM: in test, found metric: " + metrics[i].getType() + "<p>");
+					logger.info("AJM: in test, found metric: " + metrics[i].getType() + "<p>");
 					assertWithMessage(
 							"Testing the read count for execution #1", 9L,
 							metrics[i].getValue());
@@ -427,22 +413,22 @@ public class MetricsTests {
 	 * 
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testWriteMetric() throws Exception {
 		String METHOD = "testWriteMetric";
 
 		try {
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
 
-			Reporter.log("Locate job XML file: testChunkMetrics.xml<p>");
+			logger.info("Locate job XML file: testChunkMetrics.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			JobExecution execution1 = jobOp.startJobAndWaitForResult("testMetricCount",
 					jobParams);
-			Reporter.log("execution #1 JobExecution getBatchStatus()="
+			logger.info("execution #1 JobExecution getBatchStatus()="
 					+ execution1.getBatchStatus() + "<p>");
-			Reporter.log("execution #1 JobExecution getExitStatus()="
+			logger.info("execution #1 JobExecution getExitStatus()="
 					+ execution1.getExitStatus() + "<p>");
 
 			List<StepExecution> stepExecutions = jobOp
@@ -457,17 +443,17 @@ public class MetricsTests {
 				}
 			}
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="
+			logger.info("execution #1 JobExecution getBatchStatus()="
 					+ execution1.getBatchStatus() + "<p>");
 			assertWithMessage("Testing execution #1", BatchStatus.COMPLETED,
 					execution1.getBatchStatus());
 
 			Metric[] metrics = step.getMetrics();
 
-			Reporter.log("Testing the read count for execution #1<p>");
+			logger.info("Testing the read count for execution #1<p>");
 			for (int i = 0; i < metrics.length; i++) {
 				if (metrics[i].getType().equals(Metric.MetricType.WRITE_COUNT)) {
-					Reporter.log("AJM: in test, found metric: " + metrics[i].getType() + "<p>");
+					logger.info("AJM: in test, found metric: " + metrics[i].getType() + "<p>");
 					assertWithMessage(
 							"Testing the write count for execution #1", 9L,
 							metrics[i].getValue());
@@ -488,25 +474,25 @@ public class MetricsTests {
 	 * 
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testMetricsFilterCount() throws Exception {
 
 		String METHOD = "testMetricsFilterCount";
 
 		try {
 
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
 			jobParams.put("app.processFilterItem", "3");
-			Reporter.log("app.processFilterItem=3<p>");
+			logger.info("app.processFilterItem=3<p>");
 
-			Reporter.log("Locate job XML file: testMetricsFilterCount.xml<p>");
+			logger.info("Locate job XML file: testMetricsFilterCount.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			JobExecution execution1 = jobOp.startJobAndWaitForResult("testMetricsFilterCount",
 					jobParams);
 
-			Reporter.log("Obtaining StepExecutions for execution id: "
+			logger.info("Obtaining StepExecutions for execution id: "
 					+ execution1.getExecutionId() + "<p>");
 			List<StepExecution> stepExecutions = jobOp
 					.getStepExecutions(execution1.getExecutionId());
@@ -521,13 +507,13 @@ public class MetricsTests {
 				}
 			}
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="
+			logger.info("execution #1 JobExecution getBatchStatus()="
 					+ execution1.getBatchStatus() + "<p>");
 			assertWithMessage("Testing execution #1", BatchStatus.COMPLETED,
 					execution1.getBatchStatus());
 			Metric[] metrics = step.getMetrics();
 
-			Reporter.log("Testing the filter count for execution #1<p>");
+			logger.info("Testing the filter count for execution #1<p>");
 			for (int i = 0; i < metrics.length; i++) {
 				if (metrics[i].getType().equals(Metric.MetricType.FILTER_COUNT)) {
 					assertWithMessage(
@@ -548,24 +534,24 @@ public class MetricsTests {
 	 * 
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testMetricsCommitCount() throws Exception {
 
 		String METHOD = "testMetricsCommitCount";
 
 		try {
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
 			jobParams.put("app.processFilterItem", "3");
-			Reporter.log("app.processFilterItem=3<p>");
+			logger.info("app.processFilterItem=3<p>");
 
-			Reporter.log("Locate job XML file: testMetricsCommitCount.xml<p>");
+			logger.info("Locate job XML file: testMetricsCommitCount.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			JobExecution execution1 = jobOp.startJobAndWaitForResult("testMetricsCommitCount",
 					jobParams);
 
-			Reporter.log("Obtaining StepExecutions for execution id: "
+			logger.info("Obtaining StepExecutions for execution id: "
 					+ execution1.getExecutionId() + "<p>");
 			List<StepExecution> stepExecutions = jobOp
 					.getStepExecutions(execution1.getExecutionId());
@@ -580,13 +566,13 @@ public class MetricsTests {
 				}
 			}
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="
+			logger.info("execution #1 JobExecution getBatchStatus()="
 					+ execution1.getBatchStatus() + "<p>");
 			assertWithMessage("Testing execution #1", BatchStatus.COMPLETED,
 					execution1.getBatchStatus());
 			Metric[] metrics = step.getMetrics();
 
-			Reporter.log("Testing the commit count for execution #1<p>");
+			logger.info("Testing the commit count for execution #1<p>");
 			for (int i = 0; i < metrics.length; i++) {
 				if (metrics[i].getType().equals(Metric.MetricType.COMMIT_COUNT)) {
 					assertWithMessage(
@@ -610,26 +596,26 @@ public class MetricsTests {
 	 * 
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testMetricsStepTimestamps() throws Exception {
 
 		String METHOD = "testMetricsStepTimestamps";
 
 		try {
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
 			jobParams.put("app.processFilterItem", "3");
-			Reporter.log("app.processFilterItem=3<p>");
+			logger.info("app.processFilterItem=3<p>");
 
-			Reporter.log("Locate job XML file: testMetricsCommitCount.xml<p>");
+			logger.info("Locate job XML file: testMetricsCommitCount.xml<p>");
 			long time = System.currentTimeMillis();
 			Date ts = new Date(time);
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			JobExecution execution1 = jobOp.startJobAndWaitForResult("testMetricsCommitCount",
 					jobParams);
 
-			Reporter.log("Obtaining StepExecutions for execution id: "
+			logger.info("Obtaining StepExecutions for execution id: "
 					+ execution1.getExecutionId() + "<p>");
 			List<StepExecution> stepExecutions = jobOp
 					.getStepExecutions(execution1.getExecutionId());
@@ -644,14 +630,14 @@ public class MetricsTests {
 				}
 			}
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="
+			logger.info("execution #1 JobExecution getBatchStatus()="
 					+ execution1.getBatchStatus() + "<p>");
 			assertWithMessage("Testing execution #1", BatchStatus.COMPLETED,
 					execution1.getBatchStatus());
 
-			Reporter.log("AJM: testcase start time: " + ts + "<p>");
-			Reporter.log("AJM: step start time: " + step.getStartTime() + "<p>");
-			Reporter.log("AJM: step end time: " + step.getEndTime() + "<p>");
+			logger.info("AJM: testcase start time: " + ts + "<p>");
+			logger.info("AJM: step start time: " + step.getStartTime() + "<p>");
+			logger.info("AJM: step end time: " + step.getEndTime() + "<p>");
 
 			assertWithMessage("Start time of test occurs approximately before start time of step", roughlyOrdered(ts, step.getStartTime()));
 			assertWithMessage("Start time of step occurs approximately before end time of step", roughlyOrdered(step.getStartTime(), step.getEndTime()));
@@ -671,38 +657,38 @@ public class MetricsTests {
 	 * 
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testMetricsJobExecutionTimestamps() throws Exception {
 
 		String METHOD = "testMetricsJobExecutionTimestamps";
 
 		try {
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
 			jobParams.put("app.processFilterItem", "3");
-			Reporter.log("app.processFilterItem=3<p>");
+			logger.info("app.processFilterItem=3<p>");
 
-			Reporter.log("Locate job XML file: testMetricsCommitCount.xml<p>");
+			logger.info("Locate job XML file: testMetricsCommitCount.xml<p>");
 
 			long time = System.currentTimeMillis();
 			Date ts = new Date(time);
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			JobExecution execution1 = jobOp.startJobAndWaitForResult("testMetricsCommitCount",
 					jobParams);
 
 
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="
+			logger.info("execution #1 JobExecution getBatchStatus()="
 					+ execution1.getBatchStatus() + "<p>");
 			assertWithMessage("Testing execution #1", BatchStatus.COMPLETED,
 					execution1.getBatchStatus());
 
-			Reporter.log("AJM: testcase start time: " + ts + "<p>");
-			Reporter.log("AJM: job create time: " + execution1.getCreateTime() + "<p>");
-			Reporter.log("AJM: job start time: " + execution1.getStartTime() + "<p>");
-			Reporter.log("AJM: job last updated time: " + execution1.getLastUpdatedTime() + "<p>");
-			Reporter.log("AJM: job end time: " + execution1.getEndTime() + "<p>");
+			logger.info("AJM: testcase start time: " + ts + "<p>");
+			logger.info("AJM: job create time: " + execution1.getCreateTime() + "<p>");
+			logger.info("AJM: job start time: " + execution1.getStartTime() + "<p>");
+			logger.info("AJM: job last updated time: " + execution1.getLastUpdatedTime() + "<p>");
+			logger.info("AJM: job end time: " + execution1.getEndTime() + "<p>");
 
 			assertWithMessage("Start time of test occurs approximately before create time of job", roughlyOrdered(ts, execution1.getCreateTime()));
 			assertWithMessage("Create time of job occurs approximately before start time of job", roughlyOrdered(execution1.getCreateTime(), execution1.getStartTime()));
@@ -715,8 +701,8 @@ public class MetricsTests {
 
 	private static void handleException(String methodName, Exception e)
 			throws Exception {
-		Reporter.log("Caught exception: " + e.getMessage() + "<p>");
-		Reporter.log(methodName + " failed<p>");
+		logger.info("Caught exception: " + e.getMessage() + "<p>");
+		logger.info(methodName + " failed<p>");
 		throw e;
 	}
 	

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ParallelContextPropagationTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ParallelContextPropagationTests.java
@@ -28,17 +28,14 @@ import javax.batch.runtime.StepExecution;
 
 import com.ibm.jbatch.tck.ann.*;
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import java.util.logging.Logger;
 
-import org.junit.Before;
-import org.testng.Reporter;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
-
+import org.junit.jupiter.api.*;
 
 public class ParallelContextPropagationTests {
 
-	private static JobOperatorBridge jobOp = null;
+	private static final Logger logger = Logger.getLogger(ParallelContextPropagationTests.class.getName());
+	private JobOperatorBridge jobOp = null;
 
 	@TCKTest(
 		versions={"1.1.WORKING"},
@@ -59,7 +56,7 @@ public class ParallelContextPropagationTests {
 		notes={"There is no particular place in the spec that says that partitions share the same values for the getters tested as the top-level JobContext/StepContext."}
 	)
 	@Test
-	@org.junit.Test
+
 	public void testPartitionContextPropagation() throws Exception {
 
 		JobExecution je = jobOp.startJobAndWaitForResult("partitionCtxPropagation", null);
@@ -122,7 +119,7 @@ public class ParallelContextPropagationTests {
 			notes={"There is no particular place in the spec that says that split-flows share the same values for the getters tested as the top-level JobContext/StepContext."}
 		)
 	@Test
-	@org.junit.Test
+
 	public void testSplitFlowContextPropagation() throws Exception {
 
 		JobExecution je = jobOp.startJobAndWaitForResult("splitFlowCtxPropagation", null);
@@ -152,35 +149,17 @@ public class ParallelContextPropagationTests {
 		}
 	}
 
-	private static void handleException(String methodName, Exception e) throws Exception {
-		Reporter.log("Caught exception: " + e.getMessage()+"<p>");
-		Reporter.log(methodName + " failed<p>");
-		throw e;
-	}
-
-	public void setup(String[] args, Properties props) throws Exception {
-
-		String METHOD = "setup";
-
-		try {
-			jobOp = new JobOperatorBridge();
-		} catch (Exception e) {
-			handleException(METHOD, e);
-		}
-	}
-
 	/* cleanup */
 	public void  cleanup()	{		
 		jobOp = null;
 	}
 
-	@BeforeTest
-	@Before
+	@BeforeEach
 	public void beforeTest() throws ClassNotFoundException {
 		jobOp = new JobOperatorBridge(); 
 	}
 
-	@AfterTest
+	@AfterEach
 	public void afterTest() {
 		jobOp = null;
 	}

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ParallelExecutionTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/ParallelExecutionTests.java
@@ -31,14 +31,9 @@ import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.JobExecution;
 import javax.batch.runtime.StepExecution;
 
-import org.junit.BeforeClass;
-import org.testng.Reporter;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
 import com.ibm.jbatch.tck.utils.TCKJobExecutionWrapper;
+import org.junit.jupiter.api.*;
 
 
 public class ParallelExecutionTests {
@@ -47,31 +42,20 @@ public class ParallelExecutionTests {
 
 	private static final String TIME_TO_SLEEP_BEFORE_ISSUING_STOP = "1900"; 
 
-	private static JobOperatorBridge jobOp = null;
+	private JobOperatorBridge jobOp = null;
 
-	public static void setup(String[] args, Properties props) throws Exception {
-		String METHOD = "setup";
-
-		try {
-			jobOp = new JobOperatorBridge();
-		} catch (Exception e) {
-			handleException(METHOD, e);
-		}
-	}
-
-	@BeforeMethod
-	@BeforeClass
-	public static void setUp() throws Exception {
+	@BeforeEach
+	public void setUp() throws Exception {
 		jobOp = new JobOperatorBridge();
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void cleanup() throws Exception {
 	}
 
 
 	private void begin(String str) {
-		Reporter.log("Begin test method: " + str + "<p>");
+		logger.info("Begin test method: " + str + "<p>");
 	}
 
 	/*
@@ -80,18 +64,18 @@ public class ParallelExecutionTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testInvokeJobWithOnePartitionedStep() throws Exception {
 		String METHOD = "testInvokeJobWithOnePartitionedStep";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: job_partitioned_1step.xml<p>");
+			logger.info("Locate job XML file: job_partitioned_1step.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExecution = jobOp.startJobAndWaitForResult("job_partitioned_1step");
 
-			Reporter.log("JobExecution getBatchStatus()="+jobExecution.getBatchStatus()+"<p>");
+			logger.info("JobExecution getBatchStatus()="+jobExecution.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.COMPLETED, jobExecution.getBatchStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -104,7 +88,7 @@ public class ParallelExecutionTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testInvokeJobWithOnePartitionedStepExitStatus() throws Exception {
 		String METHOD = "testInvokeJobWithOnePartitionedStepExitStatus";
 		begin(METHOD);
@@ -117,10 +101,10 @@ public class ParallelExecutionTests {
 			String sleepTime = System.getProperty("ParallelExecutionTests.testInvokeJobWithOnePartitionedStepExitStatus.sleep",DEFAULT_SLEEP_TIME);
 			jobParameters.put("sleep.time", sleepTime);
 			
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExecution = jobOp.startJobAndWaitForResult("job_partitioned_1step_exitStatusTest",jobParameters);
 
-			Reporter.log("JobExecution getBatchStatus()="+jobExecution.getBatchStatus()+"<p>");
+			logger.info("JobExecution getBatchStatus()="+jobExecution.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.COMPLETED, jobExecution.getBatchStatus());
 
 			List<StepExecution> stepExecutions = jobOp.getStepExecutions(jobExecution.getExecutionId());
@@ -150,33 +134,33 @@ public class ParallelExecutionTests {
 	 * instead of running forever.
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testStopRunningPartitionedStep() throws Exception {
 		String METHOD = "testStopRunningPartitionedStep";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: job_batchlet_longrunning_partitioned.xml<p>");
+			logger.info("Locate job XML file: job_batchlet_longrunning_partitioned.xml<p>");
 
-			Reporter.log("Create job parameters<p>");
+			logger.info("Create job parameters<p>");
 			Properties overrideJobParams = new Properties();
-			Reporter.log("run.indefinitely=true<p>");
+			logger.info("run.indefinitely=true<p>");
 			overrideJobParams.setProperty("run.indefinitely" , "true");
 
-			Reporter.log("Invoke startJobWithoutWaitingForResult<p>");
+			logger.info("Invoke startJobWithoutWaitingForResult<p>");
 			JobExecution jobExecution =  jobOp.startJobWithoutWaitingForResult("job_batchlet_longrunning_partitioned", overrideJobParams);
 
 			//Sleep long enough for parallel steps to fan out
 			int sleepTime = Integer.parseInt(System.getProperty("ParallelExecutionTests.testStopRunningPartitionedStep.sleep",TIME_TO_SLEEP_BEFORE_ISSUING_STOP));
-			Reporter.log("Sleep for " + TIME_TO_SLEEP_BEFORE_ISSUING_STOP);
+			logger.info("Sleep for " + TIME_TO_SLEEP_BEFORE_ISSUING_STOP);
 			Thread.sleep(sleepTime);
 
 
-			Reporter.log("Invoke stopJobAndWaitForResult<p>");
+			logger.info("Invoke stopJobAndWaitForResult<p>");
 			jobOp.stopJobAndWaitForResult(jobExecution);
 
 			JobExecution jobExec2 = jobOp.getJobExecution(jobExecution.getExecutionId());
-			Reporter.log("JobExecution getBatchStatus()=" + jobExec2.getBatchStatus() + "<p>");
+			logger.info("JobExecution getBatchStatus()=" + jobExec2.getBatchStatus() + "<p>");
 			assertObjEquals(BatchStatus.STOPPED, jobExec2.getBatchStatus());
 
 		} catch (Exception e) {
@@ -195,43 +179,43 @@ public class ParallelExecutionTests {
 	 * restart and run to completion.
 	 */
 	@Test
-	@org.junit.Test()
+()
 	public void testStopRestartRunningPartitionedStep() throws Exception {
 		String METHOD = "testStopRestartRunningPartitionedStep";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: job_batchlet_longrunning_partitioned.xml<p>");
+			logger.info("Locate job XML file: job_batchlet_longrunning_partitioned.xml<p>");
 
-			Reporter.log("Create job parameters<p>");
+			logger.info("Create job parameters<p>");
 			Properties jobParams = new Properties();
-			Reporter.log("run.indefinitely=true<p>");
+			logger.info("run.indefinitely=true<p>");
 			jobParams.setProperty("run.indefinitely", "true");
 
-			Reporter.log("Invoke startJobWithoutWaitingForResult<p>");
+			logger.info("Invoke startJobWithoutWaitingForResult<p>");
 			JobExecution origJobExecution = jobOp.startJobWithoutWaitingForResult("job_batchlet_longrunning_partitioned", jobParams);
 
 			// Sleep long enough for parallel steps to fan out
 			int sleepTime = Integer.parseInt(System.getProperty("ParallelExecutionTests.testStopRestartRunningPartitionedStep.sleep",TIME_TO_SLEEP_BEFORE_ISSUING_STOP));
-			Reporter.log("Sleep for " + TIME_TO_SLEEP_BEFORE_ISSUING_STOP);
+			logger.info("Sleep for " + TIME_TO_SLEEP_BEFORE_ISSUING_STOP);
 			Thread.sleep(sleepTime);
 
-			Reporter.log("Invoke stopJobAndWaitForResult<p>");
+			logger.info("Invoke stopJobAndWaitForResult<p>");
 			jobOp.stopJobAndWaitForResult(origJobExecution);
 
 			JobExecution jobExec2 = jobOp.getJobExecution(origJobExecution.getExecutionId());
-			Reporter.log("JobExecution getBatchStatus()=" + jobExec2.getBatchStatus() + "<p>");
+			logger.info("JobExecution getBatchStatus()=" + jobExec2.getBatchStatus() + "<p>");
 			assertObjEquals(BatchStatus.STOPPED, jobExec2.getBatchStatus());
 
-			Reporter.log("Create restart job parameters<p>");
+			logger.info("Create restart job parameters<p>");
 			Properties restartJobParams = new Properties();
-			Reporter.log("run.indefinitely=true<p>");
+			logger.info("run.indefinitely=true<p>");
 			restartJobParams.setProperty("run.indefinitely", "false");
 
-			Reporter.log("Invoke restartJobAndWaitForResult<p>");
+			logger.info("Invoke restartJobAndWaitForResult<p>");
 			JobExecution restartedJobExec = jobOp.restartJobAndWaitForResult(origJobExecution.getExecutionId(), restartJobParams);
 
-			Reporter.log("JobExecution getBatchStatus()=" + restartedJobExec.getBatchStatus() + "<p>");
+			logger.info("JobExecution getBatchStatus()=" + restartedJobExec.getBatchStatus() + "<p>");
 			assertObjEquals(BatchStatus.COMPLETED, restartedJobExec.getBatchStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -244,18 +228,18 @@ public class ParallelExecutionTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testInvokeJobSimpleSplit() throws Exception {
 		String METHOD = "testInvokeJobSimpleSplit";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: job_split_batchlet_4steps.xml<p>");
+			logger.info("Locate job XML file: job_split_batchlet_4steps.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution execution = jobOp.startJobAndWaitForResult("job_split_batchlet_4steps");
 
-			Reporter.log("JobExecution getBatchStatus()="+execution.getBatchStatus()+"<p>");
+			logger.info("JobExecution getBatchStatus()="+execution.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.COMPLETED, execution.getBatchStatus());
 			assertObjEquals("COMPLETED", execution.getExitStatus());
 		} catch (Exception e) {
@@ -277,27 +261,27 @@ public class ParallelExecutionTests {
 	 * many times the step has been run. If the data is not persisted
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testPartitionedPlanCollectorAnalyzerReducerComplete() throws Exception {
 		String METHOD = "testPartitionedPlanCollectorAnalyzerReducerComplete";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: job_partitioned_artifacts.xml<p>");
+			logger.info("Locate job XML file: job_partitioned_artifacts.xml<p>");
 
-			Reporter.log("Create Job parameters for Execution #1<p>");
+			logger.info("Create Job parameters for Execution #1<p>");
 			Properties jobParams = new Properties();
-			Reporter.log("numPartitionsProp=3<p>");
+			logger.info("numPartitionsProp=3<p>");
 			//append "CA" to expected exit status for each partition
 			jobParams.setProperty("numPartitionsProp" , "3"); 
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution execution = jobOp.startJobAndWaitForResult("job_partitioned_artifacts", jobParams);
 
-			Reporter.log("Execution exit status = " +  execution.getExitStatus()+"<p>");
+			logger.info("Execution exit status = " +  execution.getExitStatus()+"<p>");
 			assertObjEquals("nullBeginCACACABeforeAfter", execution.getExitStatus());
 
-			Reporter.log("Execution status = " + execution.getBatchStatus()+"<p>");
+			logger.info("Execution status = " + execution.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.COMPLETED,execution.getBatchStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -318,29 +302,29 @@ public class ParallelExecutionTests {
 	 * through the collector, analyzer, and finally the reducer.
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testZeroBasedPartitionedPlanCollectorAnalyzerReducerRollback() throws Exception {
 		String METHOD = "testZeroBasedPartitionedPlanCollectorAnalyzerReducerRollback";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: job_partitioned_artifacts.xml<p>");
+			logger.info("Locate job XML file: job_partitioned_artifacts.xml<p>");
 
-			Reporter.log("Create Job parameters for Execution #1<p>");
+			logger.info("Create Job parameters for Execution #1<p>");
 			Properties jobParams = new Properties();
-			Reporter.log("numPartitionsProp=3<p>");
-			Reporter.log("failThisPartition=0<p>");
+			logger.info("numPartitionsProp=3<p>");
+			logger.info("failThisPartition=0<p>");
 			//append "CA" to expected exit status for each partition
 			jobParams.setProperty("numPartitionsProp" , "3"); 
 			jobParams.setProperty("failThisPartition" , "0"); //Remember we are 0 based
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution execution = jobOp.startJobAndWaitForResult("job_partitioned_artifacts", jobParams);
 
-			Reporter.log("Execution exit status = " +  execution.getExitStatus()+"<p>");
+			logger.info("Execution exit status = " +  execution.getExitStatus()+"<p>");
 			assertObjEquals("nullBeginCACACARollbackAfter", execution.getExitStatus());
 
-			Reporter.log("Execution status = " + execution.getBatchStatus()+"<p>");
+			logger.info("Execution status = " + execution.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.FAILED,execution.getBatchStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -367,30 +351,30 @@ public class ParallelExecutionTests {
 	 * since it does not append any data to the exit status.
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testPartitionedCollectorAnalyzerReducerChunkRestartItemCount10() throws Exception {
 
 		String METHOD = "testPartitionedCollectorAnalyzerReducerChunkRestartItemCount10";
 		try {
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
-			Reporter.log("readrecord.fail=23<p>");
-			Reporter.log("app.arraysize=30<p>");
-			Reporter.log("app.writepoints=0,5,10,15,20,25,30<p>");
-			Reporter.log("app.next.writepoints=0,5,10,15,20,25,30<p>");
+			logger.info("readrecord.fail=23<p>");
+			logger.info("app.arraysize=30<p>");
+			logger.info("app.writepoints=0,5,10,15,20,25,30<p>");
+			logger.info("app.next.writepoints=0,5,10,15,20,25,30<p>");
 			jobParams.put("readrecord.fail", "23");
 			jobParams.put("app.arraysize", "30");
 			jobParams.put("app.writepoints", "0,10,20,30");
 			jobParams.put("app.next.writepoints", "20,30");
 
-			Reporter.log("Locate job XML file: chunkrestartPartitionedCheckpt10.xml<p>");
+			logger.info("Locate job XML file: chunkrestartPartitionedCheckpt10.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			TCKJobExecutionWrapper execution1 = jobOp.startJobAndWaitForResult("chunkrestartPartitionedCheckpt10", jobParams);
 
 			{ // Use block to reduce copy/paste errors
-				Reporter.log("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
-				Reporter.log("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
+				logger.info("execution #1 JobExecution getBatchStatus()=" + execution1.getBatchStatus() + "<p>");
+				logger.info("execution #1 JobExecution getExitStatus()=" + execution1.getExitStatus() + "<p>");
 				assertWithMessage("Testing execution #1", BatchStatus.FAILED, execution1.getBatchStatus());
 
 				// '2' each from partition that gets through the first two chunks and fails during the third
@@ -411,13 +395,13 @@ public class ParallelExecutionTests {
 			{
 				long execution1Id = execution1.getExecutionId();
 				long execution1InstanceId = execution1.getInstanceId();
-				Reporter.log("Invoke restartJobAndWaitForResult with execution id: " + execution1Id + "<p>");
+				logger.info("Invoke restartJobAndWaitForResult with execution id: " + execution1Id + "<p>");
 				TCKJobExecutionWrapper execution2 = jobOp.restartJobAndWaitForResult(execution1Id, jobParams);
 
-				Reporter.log("execution #2 JobExecution getBatchStatus()=" + execution2.getBatchStatus() + "<p>");
-				Reporter.log("execution #2 JobExecution getExitStatus()=" + execution2.getExitStatus() + "<p>");
-				Reporter.log("execution #2 Job instance id=" + execution2.getInstanceId() + "<p>");
-				Reporter.log("execution #2 Job execution id=" + execution2.getExecutionId() + "<p>");
+				logger.info("execution #2 JobExecution getBatchStatus()=" + execution2.getBatchStatus() + "<p>");
+				logger.info("execution #2 JobExecution getExitStatus()=" + execution2.getExitStatus() + "<p>");
+				logger.info("execution #2 Job instance id=" + execution2.getInstanceId() + "<p>");
+				logger.info("execution #2 Job execution id=" + execution2.getExecutionId() + "<p>");
 				
 				// '2' for each of the two partitions that process chunks #2, #3, and each make one C+A call 
 				// at the end of the partition and '0' for the partition already complete.
@@ -454,39 +438,39 @@ public class ParallelExecutionTests {
      * the failed partition.
      */
     @Test
-    @org.junit.Test
+
     public void testPartitionedMapperOverrideFalseOnRestart() throws Exception {
         String METHOD = "testPartitionedMapperOverrideFalse";
         begin(METHOD);
 
         try {
-            Reporter.log("Locate job XML file: job_partitioned_artifacts.xml<p>");
+            logger.info("Locate job XML file: job_partitioned_artifacts.xml<p>");
 
-            Reporter.log("Create Job parameters for Execution #1<p>");
+            logger.info("Create Job parameters for Execution #1<p>");
             Properties jobParams = new Properties();
-            Reporter.log("numPartitionsProp=3<p>");
-            Reporter.log("failThisPartition=0<p>");
+            logger.info("numPartitionsProp=3<p>");
+            logger.info("failThisPartition=0<p>");
             //append "CA" to expected exit status for each partition
             jobParams.setProperty("numPartitionsProp" , "3"); 
             jobParams.setProperty("failThisPartition" , "0"); //Remember we are 0 based
             jobParams.setProperty("partitionsOverride", "false");
 
-            Reporter.log("Invoke startJobAndWaitForResult<p>");
+            logger.info("Invoke startJobAndWaitForResult<p>");
             JobExecution execution = jobOp.startJobAndWaitForResult("job_partitioned_artifacts", jobParams);
 
-            Reporter.log("Execution exit status = " +  execution.getExitStatus()+"<p>");
+            logger.info("Execution exit status = " +  execution.getExitStatus()+"<p>");
             assertObjEquals("nullBeginCACACARollbackAfter", execution.getExitStatus());
 
-            Reporter.log("Execution status = " + execution.getBatchStatus()+"<p>");
+            logger.info("Execution status = " + execution.getBatchStatus()+"<p>");
             assertObjEquals(BatchStatus.FAILED,execution.getBatchStatus());
             
-            Reporter.log("Set restart job parameters<p>");
+            logger.info("Set restart job parameters<p>");
             jobParams.setProperty("numPartitionsProp" , "7"); 
             jobParams.setProperty("failThisPartition" , "5"); //Remember we are 0 based
             jobParams.setProperty("partitionsOverride", "false");
             
             JobExecution execution2 = jobOp.restartJobAndWaitForResult(execution.getExecutionId(), jobParams);
-            Reporter.log("Execution exit status = " +  execution2.getExitStatus()+"<p>");
+            logger.info("Execution exit status = " +  execution2.getExitStatus()+"<p>");
             assertObjEquals("nullBeginCABeforeAfter", execution2.getExitStatus());
             
         } catch (Exception e) {
@@ -507,39 +491,39 @@ public class ParallelExecutionTests {
      * used.
      */
     @Test
-    @org.junit.Test
+
     public void testPartitionedMapperOverrideTrueDiffPartitionNumOnRestart() throws Exception {
         String METHOD = "testPartitionedMapperOverrideTrueDiffPartitionNumOnRestart";
         begin(METHOD);
 
         try {
-            Reporter.log("Locate job XML file: job_partitioned_artifacts.xml<p>");
+            logger.info("Locate job XML file: job_partitioned_artifacts.xml<p>");
 
-            Reporter.log("Create Job parameters for Execution #1<p>");
+            logger.info("Create Job parameters for Execution #1<p>");
             Properties jobParams = new Properties();
-            Reporter.log("numPartitionsProp=2<p>");
-            Reporter.log("failThisPartition=0<p>");
+            logger.info("numPartitionsProp=2<p>");
+            logger.info("failThisPartition=0<p>");
             //append "CA" to expected exit status for each partition
             jobParams.setProperty("numPartitionsProp" , "2"); 
             jobParams.setProperty("failThisPartition" , "0"); //Remember we are 0 based
             jobParams.setProperty("partitionsOverride", "false");
 
-            Reporter.log("Invoke startJobAndWaitForResult<p>");
+            logger.info("Invoke startJobAndWaitForResult<p>");
             JobExecution execution = jobOp.startJobAndWaitForResult("job_partitioned_artifacts", jobParams);
 
-            Reporter.log("Execution exit status = " +  execution.getExitStatus()+"<p>");
+            logger.info("Execution exit status = " +  execution.getExitStatus()+"<p>");
             assertObjEquals("nullBeginCACARollbackAfter", execution.getExitStatus());
 
-            Reporter.log("Execution status = " + execution.getBatchStatus()+"<p>");
+            logger.info("Execution status = " + execution.getBatchStatus()+"<p>");
             assertObjEquals(BatchStatus.FAILED,execution.getBatchStatus());
             
-            Reporter.log("Set restart job parameters<p>");
+            logger.info("Set restart job parameters<p>");
             jobParams.setProperty("numPartitionsProp" , "4"); 
             jobParams.setProperty("failThisPartition" , "3"); //Remember we are 0 based
             jobParams.setProperty("partitionsOverride", "true");
             
             JobExecution execution2 = jobOp.restartJobAndWaitForResult(execution.getExecutionId(), jobParams);
-            Reporter.log("Execution exit status = " +  execution2.getExitStatus()+"<p>");
+            logger.info("Execution exit status = " +  execution2.getExitStatus()+"<p>");
             assertObjEquals("nullBeginCACACACARollbackAfter", execution2.getExitStatus());
             
         } catch (Exception e) {
@@ -560,39 +544,39 @@ public class ParallelExecutionTests {
      * partitions should be restarted anyway, even though some had completed previously.
      */
     @Test
-    @org.junit.Test
+
     public void testPartitionedMapperOverrideTrueSamePartitionNumOnRestart() throws Exception {
         String METHOD = "testPartitionedMapperOverrideTrueSamePartitionNumOnRestart";
         begin(METHOD);
 
         try {
-            Reporter.log("Locate job XML file: job_partitioned_artifacts.xml<p>");
+            logger.info("Locate job XML file: job_partitioned_artifacts.xml<p>");
 
-            Reporter.log("Create Job parameters for Execution #1<p>");
+            logger.info("Create Job parameters for Execution #1<p>");
             Properties jobParams = new Properties();
-            Reporter.log("numPartitionsProp=3<p>");
-            Reporter.log("failThisPartition=0<p>");
+            logger.info("numPartitionsProp=3<p>");
+            logger.info("failThisPartition=0<p>");
             //append "CA" to expected exit status for each partition
             jobParams.setProperty("numPartitionsProp" , "3"); 
             jobParams.setProperty("failThisPartition" , "0"); //Remember we are 0 based
             jobParams.setProperty("partitionsOverride", "false");
 
-            Reporter.log("Invoke startJobAndWaitForResult<p>");
+            logger.info("Invoke startJobAndWaitForResult<p>");
             JobExecution execution = jobOp.startJobAndWaitForResult("job_partitioned_artifacts", jobParams);
 
-            Reporter.log("Execution exit status = " +  execution.getExitStatus()+"<p>");
+            logger.info("Execution exit status = " +  execution.getExitStatus()+"<p>");
             assertObjEquals("nullBeginCACACARollbackAfter", execution.getExitStatus());
 
-            Reporter.log("Execution status = " + execution.getBatchStatus()+"<p>");
+            logger.info("Execution status = " + execution.getBatchStatus()+"<p>");
             assertObjEquals(BatchStatus.FAILED,execution.getBatchStatus());
             
-            Reporter.log("Set restart job parameters<p>");
+            logger.info("Set restart job parameters<p>");
             jobParams.setProperty("numPartitionsProp" , "3"); 
             jobParams.setProperty("failThisPartition" , "1"); //Remember we are 0 based
             jobParams.setProperty("partitionsOverride", "true");
             
             JobExecution execution2 = jobOp.restartJobAndWaitForResult(execution.getExecutionId(), jobParams);
-            Reporter.log("Execution exit status = " +  execution2.getExitStatus()+"<p>");
+            logger.info("Execution exit status = " +  execution2.getExitStatus()+"<p>");
             assertObjEquals("nullBeginCACACARollbackAfter", execution2.getExitStatus());
             
         } catch (Exception e) {
@@ -601,8 +585,8 @@ public class ParallelExecutionTests {
     }
     
 	private static void handleException(String methodName, Exception e) throws Exception {
-		Reporter.log("Caught exception: " + e.getMessage()+"<p>");
-		Reporter.log(methodName + " failed<p>");
+		logger.info("Caught exception: " + e.getMessage()+"<p>");
+		logger.info(methodName + " failed<p>");
 		throw e;
 	}
 }

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/PartitionRerunTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/PartitionRerunTests.java
@@ -27,21 +27,18 @@ import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.JobExecution;
 import javax.batch.runtime.StepExecution;
 
-import org.junit.Before;
-import org.testng.Reporter;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
-
 import com.ibm.jbatch.tck.ann.*;
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.*;
 
 public class PartitionRerunTests {
+	private static final Logger logger = Logger.getLogger(PartitionRerunTests.class.getName());
 	static JobOperatorBridge jobOp = null;
 
 	private static void handleException(String methodName, Exception e) throws Exception {
-		Reporter.log("Caught exception: " + e.getMessage()+"<p>");
-		Reporter.log(methodName + " failed<p>");
+		logger.info("Caught exception: " + e.getMessage()+"<p>");
+		logger.info(methodName + " failed<p>");
 		throw e;
 	}
 
@@ -61,13 +58,12 @@ public class PartitionRerunTests {
 		jobOp = null;
 	}
 
-	@BeforeTest
-	@Before
+	@BeforeEach
 	public void beforeTest() throws ClassNotFoundException {
 		jobOp = new JobOperatorBridge(); 
 	}
 
-	@AfterTest
+	@AfterEach
 	public void afterTest() {
 		jobOp = null;
 	}
@@ -97,7 +93,7 @@ public class PartitionRerunTests {
 		notes={"The spec doesn't explicitly describe this combination of partitions plus allow-start-if-complete=\"true\", but it seems the only valid interpretation."}
 	)
 	@Test
-	@org.junit.Test
+
 	public void testRerunPartitionAndBatchlet() throws Exception {
 		Properties origParams = new Properties();
 		origParams.setProperty("force.failure", "true");

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/PropertySubstitutionTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/PropertySubstitutionTests.java
@@ -26,38 +26,25 @@ import java.util.Properties;
 import javax.batch.runtime.JobExecution;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import java.util.logging.Logger;
 
-import org.junit.BeforeClass;
-import org.testng.Reporter;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.*;
 
 public class PropertySubstitutionTests {
 
-	private static JobOperatorBridge jobOp;
+	private static final Logger logger = Logger.getLogger(PropertySubstitutionTests.class.getName());
+	private JobOperatorBridge jobOp;
 
-	public static void setup(String[] args, Properties props) throws Exception {
-		String METHOD = "setup";
-
-		try {
-			jobOp = new JobOperatorBridge();
-		} catch (Exception e) {
-			handleException(METHOD, e);
-		}
-	}
-
-	@BeforeMethod
-	@BeforeClass
-	public static void setUp() throws Exception {
+	@BeforeEach
+	public void setUp() throws Exception {
 		jobOp = new JobOperatorBridge();
 	}
 
-	@AfterMethod
-	public static void tearDown() throws Exception {
+	@AfterEach
+	public void tearDown() throws Exception {
 	}
 
-	@AfterMethod
+	@AfterEach
 	public void cleanup() throws Exception {
 		// Clear this property for next test
 		System.clearProperty("property.junit.result");
@@ -74,21 +61,21 @@ public class PropertySubstitutionTests {
 	 * job xml.
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testBatchArtifactPropertyInjection() throws Exception {
 		String METHOD = "testBatchArtifactPropertyInjection";
 
 		try {
-			Reporter.log("Locate job XML file: job_properties2.xml<p>");
+			logger.info("Locate job XML file: job_properties2.xml<p>");
 
-			Reporter.log("Set system property: property.junit.propName=myProperty1<p>");
+			logger.info("Set system property: property.junit.propName=myProperty1<p>");
 			System.setProperty("property.junit.propName", "myProperty1");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_properties2");
 
 			String result = System.getProperty("property.junit.result");
-			Reporter.log("Test result: " + result + "<p>");
+			logger.info("Test result: " + result + "<p>");
 			assertObjEquals("value1", result);
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -107,22 +94,22 @@ public class PropertySubstitutionTests {
 	 * job xml even if the Java field is initialized.
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testInitializedPropertyIsOverwritten() throws Exception {
 
 		String METHOD = "testInitializedPropertyIsOverwritten";
 
 		try {
-			Reporter.log("Locate job XML file: job_properties2.xml<p>");
+			logger.info("Locate job XML file: job_properties2.xml<p>");
 
-			Reporter.log("Set system property: property.junit.propName=myProperty2<p>");
+			logger.info("Set system property: property.junit.propName=myProperty2<p>");
 			System.setProperty("property.junit.propName", "myProperty2");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_properties2");
 
 			String result = System.getProperty("property.junit.result");
-			Reporter.log("Test result: " + result + "<p>");
+			logger.info("Test result: " + result + "<p>");
 			assertObjEquals("value2", result);
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -140,28 +127,28 @@ public class PropertySubstitutionTests {
 	 * injecting the property into a batch artifact
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testPropertyWithJobParameter() throws Exception {
 
 		String METHOD = "testPropertyWithJobParameter";
 
 		try {
-			Reporter.log("Locate job XML file: job_properties2.xml<p>");
+			logger.info("Locate job XML file: job_properties2.xml<p>");
 
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParameters = new Properties();
 			String expectedResult = "mySubmittedValue";
-			Reporter.log("mySubmittedPropr=" + expectedResult + "<p>");
+			logger.info("mySubmittedPropr=" + expectedResult + "<p>");
 			jobParameters.setProperty("mySubmittedProp", expectedResult);
 
-			Reporter.log("Set system property: property.junit.propName=mySubmittedProp<p>");
+			logger.info("Set system property: property.junit.propName=mySubmittedProp<p>");
 			System.setProperty("property.junit.propName", "mySubmittedProp");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_properties2", jobParameters);
 
 			String result = System.getProperty("property.junit.result");
-			Reporter.log("Test result: " + result + "<p>");
+			logger.info("Test result: " + result + "<p>");
 			assertObjEquals(expectedResult, result);
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -180,22 +167,22 @@ public class PropertySubstitutionTests {
 	 * value provided through the job xml
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testDefaultPropertyName() throws Exception {
 
 		String METHOD = "testDefaultPropertyName";
 
 		try {
-			Reporter.log("Locate job XML file: job_properties2.xml<p>");
+			logger.info("Locate job XML file: job_properties2.xml<p>");
 
-			Reporter.log("Set system property:property.junit.propName=property4<p>");
+			logger.info("Set system property:property.junit.propName=property4<p>");
 			System.setProperty("property.junit.propName", "property4");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_properties2");
 
 			String result = System.getProperty("property.junit.result");
-			Reporter.log("Test result: " + result + "<p>");
+			logger.info("Test result: " + result + "<p>");
 			assertObjEquals("value4", result);
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -212,22 +199,22 @@ public class PropertySubstitutionTests {
 	 * value provided through the job xml.
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testGivenPropertyName() throws Exception {
 
 		String METHOD = "testGivenPropertyName";
 
 		try {
-			Reporter.log("Locate job XML file: job_properties2.xml<p>");
+			logger.info("Locate job XML file: job_properties2.xml<p>");
 
-			Reporter.log("Set system property:property.junit.propName=myProperty4<p>");
+			logger.info("Set system property:property.junit.propName=myProperty4<p>");
 			System.setProperty("property.junit.propName", "myProperty4");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_properties2");
 
 			String result = System.getProperty("property.junit.result");
-			Reporter.log("Test result: " + result + "<p>");
+			logger.info("Test result: " + result + "<p>");
 			assertObjEquals("value4", result);
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -244,22 +231,22 @@ public class PropertySubstitutionTests {
 	 * Verify that the injected property value is from the artifact level property.
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testPropertyInnerScopePrecedence() throws Exception {
 
 		String METHOD = "testPropertyInnerScopePrecedence";
 
 		try {
-			Reporter.log("Locate job XML file: job_properties2.xml<p>");
+			logger.info("Locate job XML file: job_properties2.xml<p>");
 
-			Reporter.log("Set system property:property.junit.propName=batchletProp<p>");
+			logger.info("Set system property:property.junit.propName=batchletProp<p>");
 			System.setProperty("property.junit.propName", "batchletProp");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_properties2");
 
 			String result = System.getProperty("property.junit.result");
-			Reporter.log("Test result: " + result + "<p>");
+			logger.info("Test result: " + result + "<p>");
 			assertObjEquals("batchletPropValue", result);
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -278,26 +265,26 @@ public class PropertySubstitutionTests {
 	 * batctlet artifact. 
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testPropertyQuestionMarkSimple() throws Exception {
 
 		String METHOD = "testPropertyQuestionMarkSimple";
 
 		try {
-			Reporter.log("Locate job XML file: job_properties2.xml<p>");
+			logger.info("Locate job XML file: job_properties2.xml<p>");
 
-			Reporter.log("Set system property:property.junit.propName=defaultPropName1<p>");
+			logger.info("Set system property:property.junit.propName=defaultPropName1<p>");
 			System.setProperty("property.junit.propName", "defaultPropName1");
 
-			Reporter.log("Set system property:file.name.junit=myfile1.txt<p>");
+			logger.info("Set system property:file.name.junit=myfile1.txt<p>");
 			System.setProperty("file.name.junit", "myfile1.txt");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_properties2");
 
 			// String result = jobExec.getStatus();
 			String result = System.getProperty("property.junit.result");
-			Reporter.log("Test result: " + result + "<p>");
+			logger.info("Test result: " + result + "<p>");
 			assertObjEquals("myfile1.txt", result);
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -316,26 +303,26 @@ public class PropertySubstitutionTests {
 	 * batctlet artifact. 
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testPropertyQuestionMarkComplex() throws Exception {
 
 		String METHOD = "testPropertyQuestionMarkComplex";
 
 		try {
-			Reporter.log("Locate job XML file: job_properties2.xml<p>");
+			logger.info("Locate job XML file: job_properties2.xml<p>");
 
-			Reporter.log("Set system property:property.junit.propName=defaultPropName2<p>");
+			logger.info("Set system property:property.junit.propName=defaultPropName2<p>");
 			System.setProperty("property.junit.propName", "defaultPropName2");
 
-			Reporter.log("Set system property:file.name.junit=myfile2.txt<p>");
+			logger.info("Set system property:file.name.junit=myfile2.txt<p>");
 			System.setProperty("file.name.junit", "myfile2");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_properties2");
 
 			// String result = jobExec.getStatus();
 			String result = System.getProperty("property.junit.result");
-			Reporter.log("Test result: " + result + "<p>");
+			logger.info("Test result: " + result + "<p>");
 
 			assertObjEquals(File.separator + "myfile2.txt", result);
 		} catch (Exception e) {
@@ -353,27 +340,27 @@ public class PropertySubstitutionTests {
 	 * value provided through the job xml. 
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testPropertyWithConcatenation() throws Exception {
 
 		String METHOD = "testPropertyWithConcatenation";
 
 		try {
-			Reporter.log("Locate job XML file: job_properties2.xml<p>");
+			logger.info("Locate job XML file: job_properties2.xml<p>");
 
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParameters = new Properties();
-			Reporter.log("myFilename=testfile1<p>");
+			logger.info("myFilename=testfile1<p>");
 			jobParameters.setProperty("myFilename", "testfile1");
 
-			Reporter.log("Set system property:file.name.junit=myConcatProp<p>");
+			logger.info("Set system property:file.name.junit=myConcatProp<p>");
 			System.setProperty("property.junit.propName", "myConcatProp");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_properties2", jobParameters);
 
 			String result = System.getProperty("property.junit.result");
-			Reporter.log("Test result: " + result + "<p>");
+			logger.info("Test result: " + result + "<p>");
 			assertObjEquals("testfile1.txt", result);
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -394,29 +381,29 @@ public class PropertySubstitutionTests {
 	 * 
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testJavaSystemProperty() throws Exception {
 
 		String METHOD = "testJavaSystemProperty";
 
 		try {
-			Reporter.log("Locate job XML file: job_properties2.xml<p>");
+			logger.info("Locate job XML file: job_properties2.xml<p>");
 
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParameters = new Properties();
-			Reporter.log("myFilename=testfile2<p>");
+			logger.info("myFilename=testfile2<p>");
 			jobParameters.setProperty("myFilename", "testfile2");
 
-			Reporter.log("Set system property:file.name.junit=myJavaSystemProp<p>");
+			logger.info("Set system property:file.name.junit=myJavaSystemProp<p>");
 			System.setProperty("property.junit.propName", "myJavaSystemProp");
 
-			Reporter.log("Invoke startJobAndWaitForResult<p>");
+			logger.info("Invoke startJobAndWaitForResult<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_properties2", jobParameters);
 			String result = System.getProperty("property.junit.result");
 
 			String pathSep = System.getProperty("file.separator");
 
-			Reporter.log("Test result: " + pathSep + "test" + pathSep + "testfile2.txt<p>");
+			logger.info("Test result: " + pathSep + "test" + pathSep + "testfile2.txt<p>");
 			assertObjEquals(pathSep + "test" + pathSep + "testfile2.txt", result);
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -425,8 +412,8 @@ public class PropertySubstitutionTests {
 	}
 
 	private static void handleException(String methodName, Exception e) throws Exception {
-		Reporter.log("Caught exception: " + e.getMessage() + "<p>");
-		Reporter.log(methodName + " failed<p>");
+		logger.info("Caught exception: " + e.getMessage() + "<p>");
+		logger.info(methodName + " failed<p>");
 		throw e;
 	}
 }

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/RestartNotMostRecentTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/RestartNotMostRecentTests.java
@@ -25,16 +25,13 @@ import java.util.Properties;
 import javax.batch.operations.JobExecutionNotMostRecentException;
 import javax.batch.runtime.JobExecution;
 
-import org.junit.Before;
-import org.testng.Reporter;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
-
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.*;
 
 public class RestartNotMostRecentTests {
-	
+
+	private static final Logger logger = Logger.getLogger(RestartNotMostRecentTests.class.getName());
 	private JobOperatorBridge jobOp = null;
 	
 	/*
@@ -45,32 +42,32 @@ public class RestartNotMostRecentTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testRestartNotMostRecentException() throws Exception {
 		String METHOD = "testRestartNotMostRecentException";
 		
 		try {
-			Reporter.log("starting job");
+			logger.info("starting job");
 			Properties jobParams = new Properties();
-			Reporter.log("execution.number=1<p>");
+			logger.info("execution.number=1<p>");
 			jobParams.put("execution.number", "1");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_attributes_restart_true_test", jobParams);
 			
 			Properties restartParams = new Properties();
-			Reporter.log("execution.number=2<p>");
+			logger.info("execution.number=2<p>");
 			restartParams.put("execution.number", "2");
 			jobOp.restartJobAndWaitForResult(jobExec.getExecutionId(), restartParams);
 		
 			try {
-				Reporter.log("Trying to execute the first job execution again.");
+				logger.info("Trying to execute the first job execution again.");
 				jobOp.restartJobAndWaitForResult(jobExec.getExecutionId(), restartParams);
 				assertWithMessage("It should have thrown JobExecutionNotMostRecentException", false);
 			} catch(JobExecutionNotMostRecentException e) {
 				assertWithMessage("JobExecutionNotMostRecentException thrown", true);
 			}
 
-			Reporter.log("Job Status = " + jobExec.getBatchStatus());
-			Reporter.log("job completed");
+			logger.info("Job Status = " + jobExec.getBatchStatus());
+			logger.info("job completed");
 			
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -79,8 +76,8 @@ public class RestartNotMostRecentTests {
 	
 	
 	private static void handleException(String methodName, Exception e) throws Exception {
-		Reporter.log("Caught exception: " + e.getMessage()+"<p>");
-		Reporter.log(methodName + " failed<p>");
+		logger.info("Caught exception: " + e.getMessage()+"<p>");
+		logger.info(methodName + " failed<p>");
 		throw e;
 	}
 
@@ -101,13 +98,12 @@ public class RestartNotMostRecentTests {
 
 	}
 
-	@BeforeTest
-	@Before
+	@BeforeEach
 	public void beforeTest() throws ClassNotFoundException {
 		jobOp = new JobOperatorBridge(); 
 	}
 
-	@AfterTest
+	@AfterEach
 	public void afterTest() {
 		jobOp = null;
 	}

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/RetryListenerTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/RetryListenerTests.java
@@ -26,30 +26,17 @@ import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.JobExecution;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import java.util.logging.Logger;
 
-import org.junit.BeforeClass;
-import org.testng.Reporter;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.*;
 
 public class RetryListenerTests {
 
-	private static JobOperatorBridge jobOp = null;
+	private static final Logger logger = Logger.getLogger(RetryListenerTests.class.getName());
+	private JobOperatorBridge jobOp = null;
 
-	public static void setup(String[] args, Properties props) throws Exception {
-
-		String METHOD = "setup";
-
-		try {
-			jobOp = new JobOperatorBridge();
-		} catch (Exception e) {
-			handleException(METHOD, e);
-		}
-	}
-
-	@BeforeMethod
-	@BeforeClass
-	public static void setUp() throws Exception {
+	@BeforeEach
+	public void setUp() throws Exception {
 		jobOp = new JobOperatorBridge();
 	}
 
@@ -67,29 +54,29 @@ public class RetryListenerTests {
 	 * @test_Strategy: Test that the onRetryReadException listener is invoked when a retryable exception occurs on a read.
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testRetryReadListener() throws Exception {
 		String METHOD = "testRetryReadListener";
 
 		try {
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
-			Reporter.log("execution.number=1<p>");
-			Reporter.log("readrecord.fail=8,13,22<p>");
-			Reporter.log("app.arraysize=30<p>");
+			logger.info("execution.number=1<p>");
+			logger.info("readrecord.fail=8,13,22<p>");
+			logger.info("app.arraysize=30<p>");
 			jobParams.put("execution.number", "1");
 			jobParams.put("readrecord.fail", "8,13,22");
 			jobParams.put("app.arraysize", "30");
 
-			Reporter.log("Locate job XML file: job_retry_listener_test.xml<p>");
+			logger.info("Locate job XML file: job_retry_listener_test.xml<p>");
 
 
 
-			Reporter.log("Invoking startJobAndWaitForResult for Execution #1<p>");
+			logger.info("Invoking startJobAndWaitForResult for Execution #1<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_retry_listener_test",jobParams);
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()=" + jobExec.getBatchStatus() + "<p>");
-			Reporter.log("execution #1 JobExecution getExitStatus()=" + jobExec.getExitStatus() + "<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()=" + jobExec.getBatchStatus() + "<p>");
+			logger.info("execution #1 JobExecution getExitStatus()=" + jobExec.getExitStatus() + "<p>");
 			assertWithMessage("Testing execution #1", BatchStatus.FAILED, jobExec.getBatchStatus());
 			assertWithMessage("Testing execution #1", "Retry listener invoked", jobExec.getExitStatus());
 		} catch(Exception e) {
@@ -105,29 +92,29 @@ public class RetryListenerTests {
 	 * @test_Strategy: Test that the onRetryProcessException listener is invoked when a retryable exception occurs on a process.
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testRetryProcessListener() throws Exception {
 		String METHOD = "testRetryProcessListener";
 
 		try {
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
-			Reporter.log("execution.number=1<p>");
-			Reporter.log("processrecord.fail=8,13,22<p>");
-			Reporter.log("app.arraysize=30<p>");
+			logger.info("execution.number=1<p>");
+			logger.info("processrecord.fail=8,13,22<p>");
+			logger.info("app.arraysize=30<p>");
 			jobParams.put("execution.number", "1");
 			jobParams.put("processrecord.fail", "8,13,22");
 			jobParams.put("app.arraysize", "30");
 
-			Reporter.log("Locate job XML file: job_retry_listener_test.xml<p>");
+			logger.info("Locate job XML file: job_retry_listener_test.xml<p>");
 
 
 
-			Reporter.log("Invoking startJobAndWaitForResult for Execution #1<p>");
+			logger.info("Invoking startJobAndWaitForResult for Execution #1<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_retry_listener_test",jobParams);
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()=" + jobExec.getBatchStatus() + "<p>");
-			Reporter.log("execution #1 JobExecution getExitStatus()=" + jobExec.getExitStatus() + "<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()=" + jobExec.getBatchStatus() + "<p>");
+			logger.info("execution #1 JobExecution getExitStatus()=" + jobExec.getExitStatus() + "<p>");
 			assertWithMessage("Testing execution #1", BatchStatus.FAILED, jobExec.getBatchStatus());
 			assertWithMessage("Testing execution #1", "Retry listener invoked", jobExec.getExitStatus());
 		} catch(Exception e) {
@@ -143,30 +130,30 @@ public class RetryListenerTests {
 	 * @test_Strategy: Test that the onRetryWriteException listener is invoked when a retryable exception occurs on a write.
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testRetryWriteListener() throws Exception {
 		String METHOD = "testRetryWriteListener";
 
 		try {
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParams = new Properties();
-			Reporter.log("execution.number=1<p>");
-			Reporter.log("writerecord.fail=8,13,22<p>");
-			Reporter.log("app.arraysize=30<p>");
+			logger.info("execution.number=1<p>");
+			logger.info("writerecord.fail=8,13,22<p>");
+			logger.info("app.arraysize=30<p>");
 			jobParams.put("execution.number", "1");
 			jobParams.put("writerecord.fail", "8,13,22");
 			jobParams.put("app.arraysize", "30");
 
 
-			Reporter.log("Locate job XML file: job_retry_listener_test.xml<p>");
+			logger.info("Locate job XML file: job_retry_listener_test.xml<p>");
 
 
 
-			Reporter.log("Invoking startJobAndWaitForResult for Execution #1<p>");
+			logger.info("Invoking startJobAndWaitForResult for Execution #1<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_retry_listener_test",jobParams);
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()=" + jobExec.getBatchStatus() + "<p>");
-			Reporter.log("execution #1 JobExecution getExitStatus()=" + jobExec.getExitStatus() + "<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()=" + jobExec.getBatchStatus() + "<p>");
+			logger.info("execution #1 JobExecution getExitStatus()=" + jobExec.getExitStatus() + "<p>");
 			assertWithMessage("Testing execution #1", BatchStatus.FAILED, jobExec.getBatchStatus());
 			assertWithMessage("Testing execution #1", "Retry listener invoked", jobExec.getExitStatus());
 		} catch(Exception e) {
@@ -175,8 +162,8 @@ public class RetryListenerTests {
 	}
 
 	private static void handleException(String methodName, Exception e) throws Exception {
-		Reporter.log("Caught exception: " + e.getMessage()+"<p>");
-		Reporter.log(methodName + " failed<p>");
+		logger.info("Caught exception: " + e.getMessage()+"<p>");
+		logger.info(methodName + " failed<p>");
 		throw e;
 	}
 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/SplitFlowTransitionLoopTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/SplitFlowTransitionLoopTests.java
@@ -25,16 +25,13 @@ import java.util.Properties;
 import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.JobExecution;
 
-import org.junit.Before;
-import org.testng.Reporter;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
-
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.*;
 
 public class SplitFlowTransitionLoopTests {
 
+	private static final Logger logger = Logger.getLogger(SplitFlowTransitionLoopTests.class.getName());
 	private JobOperatorBridge jobOp = null;
 
 	/**
@@ -82,26 +79,26 @@ public class SplitFlowTransitionLoopTests {
 	 * @throws Exception
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testSplitFlowTransitionLoopSplitFlowSplit() throws Exception {
 
 		String METHOD = "testSplitFlowTransitionLoopSplitFlowSplit";
 
 		try {
-			Reporter.log("starting job");
+			logger.info("starting job");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("split_flow_transition_loop_splitflowsplit", null);
-			Reporter.log("Job Status = " + jobExec.getBatchStatus());
+			logger.info("Job Status = " + jobExec.getBatchStatus());
 
 			assertWithMessage("Job completed", BatchStatus.COMPLETED, jobExec.getBatchStatus());
-			Reporter.log("job completed");
+			logger.info("job completed");
 		} catch (Exception e) {
 			handleException(METHOD, e);
 		}
 	}
 
 	private static void handleException(String methodName, Exception e) throws Exception {
-		Reporter.log("Caught exception: " + e.getMessage()+"<p>");
-		Reporter.log(methodName + " failed<p>");
+		logger.info("Caught exception: " + e.getMessage()+"<p>");
+		logger.info(methodName + " failed<p>");
 		throw e;
 	}
 
@@ -122,13 +119,12 @@ public class SplitFlowTransitionLoopTests {
 		}
 	}
 
-	@BeforeTest
-	@Before
+	@BeforeEach
 	public void beforeTest() throws ClassNotFoundException {
 		jobOp = new JobOperatorBridge(); 
 	}
 
-	@AfterTest
+	@AfterEach
 	public void afterTest() {
 		jobOp = null;
 	}

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/SplitTransitioningTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/SplitTransitioningTests.java
@@ -28,16 +28,13 @@ import javax.batch.operations.JobStartException;
 import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.JobExecution;
 
-import org.junit.Before;
-import org.testng.Reporter;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
-
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.*;
 
 public class SplitTransitioningTests {
 
+	private static final Logger logger = Logger.getLogger(SplitTransitioningTests.class.getName());
 	private JobOperatorBridge jobOp = null;
 
 	/**
@@ -53,20 +50,20 @@ public class SplitTransitioningTests {
 	 * @throws IOException
 	 * @throws InterruptedException
 	 */
-	@Test @org.junit.Test
+	@Test
 	public void testSplitTransitionToStep() throws Exception {
 
 		String METHOD = "testSplitTransitionToStep";
 
 		try {
-			Reporter.log("starting job");
+			logger.info("starting job");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("split_transition_to_step", null);
-			Reporter.log("Job Status = " + jobExec.getBatchStatus());
+			logger.info("Job Status = " + jobExec.getBatchStatus());
 
 			assertWithMessage("Split transitioned to step", "step1", jobExec.getExitStatus());
 
 			assertWithMessage("Job completed", BatchStatus.COMPLETED, jobExec.getBatchStatus());
-			Reporter.log("job completed");
+			logger.info("job completed");
 		} catch (Exception e) {
 			handleException(METHOD, e); 
 		}
@@ -108,20 +105,20 @@ public class SplitTransitioningTests {
 	 * @throws InterruptedException
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testSplitTransitionToStepOutOfScope() throws Exception {
 
 		String METHOD = "testSplitTransitionToStepOutOfScope";
 
 		try {
-			Reporter.log("starting job");
+			logger.info("starting job");
 			
 			boolean seenException = false;
 			JobExecution jobExec = null;
 			try {
 				jobExec = jobOp.startJobAndWaitForResult("split_transition_to_step_out_of_scope", null);
 			} catch (JobStartException e) {
-				Reporter.log("Caught JobStartException:  " + e.getLocalizedMessage());
+				logger.info("Caught JobStartException:  " + e.getLocalizedMessage());
 				seenException = true;
 			}
 			
@@ -130,7 +127,7 @@ public class SplitTransitioningTests {
 			
 			// If we didn't catch an exception that we require that the implementation fail the job execution.
 			if (!seenException) {
-				Reporter.log("Didn't catch JobstartException, Job Batch Status = " + jobExec.getBatchStatus());
+				logger.info("Didn't catch JobstartException, Job Batch Status = " + jobExec.getBatchStatus());
 				assertWithMessage("Job should have failed because of out of scope execution elements.", BatchStatus.FAILED, jobExec.getBatchStatus());
 			}
 		} catch (Exception e) {
@@ -151,7 +148,7 @@ public class SplitTransitioningTests {
 	 * @throws IOException
 	 * @throws InterruptedException
 	 */
-	@Test @org.junit.Test
+	@Test
 	public void testSplitTransitionToDecision() throws Exception {
 
 		String METHOD = "testSplitTransitionToDecision";
@@ -164,21 +161,21 @@ public class SplitTransitioningTests {
 				<end exit-status="ThatsAllFolks" on="DECIDER_EXIT_STATUS*2" />
 			</decision>
 			 */
-			Reporter.log("starting job");
+			logger.info("starting job");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("split_transition_to_decision", null);
-			Reporter.log("Job Status = " + jobExec.getBatchStatus());
+			logger.info("Job Status = " + jobExec.getBatchStatus());
 
 			assertWithMessage("Job Exit Status is from decider", exitStatus, jobExec.getExitStatus());
 			assertWithMessage("Job completed", BatchStatus.COMPLETED, jobExec.getBatchStatus());
-			Reporter.log("job completed");
+			logger.info("job completed");
 		} catch (Exception e) {
 			handleException(METHOD, e);
 		}
 	}
 
 	private static void handleException(String methodName, Exception e) throws Exception {
-		Reporter.log("Caught exception: " + e.getMessage()+"<p>");
-		Reporter.log(methodName + " failed<p>");
+		logger.info("Caught exception: " + e.getMessage()+"<p>");
+		logger.info(methodName + " failed<p>");
 		throw e;
 	}
 
@@ -199,13 +196,12 @@ public class SplitTransitioningTests {
 		}
 	} 
 
-	@BeforeTest
-	@Before
+	@BeforeEach
 	public void beforeTest() throws ClassNotFoundException {
 		jobOp = new JobOperatorBridge(); 
 	}
 
-	@AfterTest
+	@AfterEach
 	public void afterTest() {
 		jobOp = null;
 	}

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/StartLimitTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/StartLimitTests.java
@@ -26,17 +26,14 @@ import java.util.Properties;
 import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.StepExecution;
 
-import org.junit.Before;
-import org.testng.Reporter;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
-
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
 import com.ibm.jbatch.tck.utils.TCKJobExecutionWrapper;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.*;
 
 public class StartLimitTests {
 
+	private static final Logger logger = Logger.getLogger(StartLimitTests.class.getName());
 	private JobOperatorBridge jobOp = null;
 
 
@@ -86,7 +83,7 @@ public class StartLimitTests {
 	 *                 
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testStartLimitVariation1() throws Exception {
 
 		String METHOD = "testStartLimitVariation1";
@@ -109,16 +106,16 @@ public class StartLimitTests {
 				jobParameters.put("execution.number", execString);
 				jobParameters.put("batchlet.ref", "startLimitStateMachineVariation1Batchlet");
 				if (i == 1) {
-					Reporter.log("Invoking startJobAndWaitForResult for Execution #1<p>");
+					logger.info("Invoking startJobAndWaitForResult for Execution #1<p>");
 					exec = jobOp.startJobAndWaitForResult("startLimitTests", jobParameters);
 				} else {
-					Reporter.log("Invoke restartJobAndWaitForResult<p>");
+					logger.info("Invoke restartJobAndWaitForResult<p>");
 					exec = jobOp.restartJobAndWaitForResult(lastExecutionId, jobParameters);
 				}
 				lastExecutionId = exec.getExecutionId();
 
-				Reporter.log("Execution #" + i + " JobExecution getBatchStatus()="+exec.getBatchStatus()+"<p>");
-				Reporter.log("Execution #" + i + " JobExecution getExitStatus()="+exec.getExitStatus()+"<p>");
+				logger.info("Execution #" + i + " JobExecution getBatchStatus()="+exec.getBatchStatus()+"<p>");
+				logger.info("Execution #" + i + " JobExecution getExitStatus()="+exec.getExitStatus()+"<p>");
 
 				// Typical TCK test execution # is 1-indexed but array is 0-indexed so use 'i-1' below.
 				assertWithMessage("Testing execution #" + i, expectedExitStatuses[i-1], exec.getExitStatus());
@@ -160,7 +157,7 @@ public class StartLimitTests {
 	 * @test_Strategy:
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testStartLimitVariation2() throws Exception {
 
 		String METHOD = "testStartLimitVariation2";
@@ -190,16 +187,16 @@ public class StartLimitTests {
 					jobParameters.put("stop.after.step.4","DON'T_MATCH_ME");
 				}
 				if (i == 1) {
-					Reporter.log("Invoking startJobAndWaitForResult for Execution #1<p>");
+					logger.info("Invoking startJobAndWaitForResult for Execution #1<p>");
 					exec = jobOp.startJobAndWaitForResult("startLimitTests", jobParameters);
 				} else {
-					Reporter.log("Invoke restartJobAndWaitForResult<p>");
+					logger.info("Invoke restartJobAndWaitForResult<p>");
 					exec = jobOp.restartJobAndWaitForResult(lastExecutionId, jobParameters);
 				}
 				lastExecutionId = exec.getExecutionId();
 
-				Reporter.log("Execution #" + i + " JobExecution getBatchStatus()="+exec.getBatchStatus()+"<p>");
-				Reporter.log("Execution #" + i + " JobExecution getExitStatus()="+exec.getExitStatus()+"<p>");
+				logger.info("Execution #" + i + " JobExecution getBatchStatus()="+exec.getBatchStatus()+"<p>");
+				logger.info("Execution #" + i + " JobExecution getExitStatus()="+exec.getExitStatus()+"<p>");
 
 				// Typical TCK test execution # is 1-indexed but array is 0-indexed so use 'i-1' below.
 				assertWithMessage("Testing execution #" + i, expectedExitStatuses[i-1], exec.getExitStatus());
@@ -270,7 +267,7 @@ public class StartLimitTests {
 	 * @test_Strategy:
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testStartLimitVariation3() throws Exception {
 
 		String METHOD = "testStartLimitVariation3";
@@ -292,16 +289,16 @@ public class StartLimitTests {
 				jobParameters.put("execution.number", execString);
 				jobParameters.put("batchlet.ref", "startLimitStateMachineVariation3Batchlet");
 				if (i == 1) {
-					Reporter.log("Invoking startJobAndWaitForResult for Execution #1<p>");
+					logger.info("Invoking startJobAndWaitForResult for Execution #1<p>");
 					exec = jobOp.startJobAndWaitForResult("startLimitTests", jobParameters);
 				} else {
-					Reporter.log("Invoke restartJobAndWaitForResult<p>");
+					logger.info("Invoke restartJobAndWaitForResult<p>");
 					exec = jobOp.restartJobAndWaitForResult(lastExecutionId, jobParameters);
 				}
 				lastExecutionId = exec.getExecutionId();
 
-				Reporter.log("Execution #" + i + " JobExecution getBatchStatus()="+exec.getBatchStatus()+"<p>");
-				Reporter.log("Execution #" + i + " JobExecution getExitStatus()="+exec.getExitStatus()+"<p>");
+				logger.info("Execution #" + i + " JobExecution getBatchStatus()="+exec.getBatchStatus()+"<p>");
+				logger.info("Execution #" + i + " JobExecution getExitStatus()="+exec.getExitStatus()+"<p>");
 
 				// Typical TCK test execution # is 1-indexed but array is 0-indexed so use 'i-1' below.
 				assertWithMessage("Testing execution #" + i, expectedExitStatuses[i-1], exec.getExitStatus());
@@ -340,8 +337,8 @@ public class StartLimitTests {
 
 
 	private static void handleException(String methodName, Exception e) throws Exception {
-		Reporter.log("Caught exception: " + e.getMessage()+"<p>");
-		Reporter.log(methodName + " failed<p>");
+		logger.info("Caught exception: " + e.getMessage()+"<p>");
+		logger.info(methodName + " failed<p>");
 		throw e;
 	}
 
@@ -362,13 +359,12 @@ public class StartLimitTests {
 
 	}
 
-	@BeforeTest
-	@Before
+	@BeforeEach
 	public void beforeTest() throws ClassNotFoundException {
 		jobOp = new JobOperatorBridge(); 
 	}
 
-	@AfterTest
+	@AfterEach
 	public void afterTest() {
 		jobOp = null;
 	}

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/StepExecutionTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/StepExecutionTests.java
@@ -37,40 +37,25 @@ import com.ibm.jbatch.tck.artifacts.reusable.MyBatchletImpl;
 import com.ibm.jbatch.tck.artifacts.reusable.MyPersistentUserData;
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
 
-import org.junit.BeforeClass;
-import org.testng.Reporter;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.*;
 
 public class StepExecutionTests {
 
 	private final static Logger logger = Logger.getLogger(StepExecutionTests.class.getName());
 
-	private static JobOperatorBridge jobOp;
+	private JobOperatorBridge jobOp;
 
-	public static void setup(String[] args, Properties props) throws Exception {
-		String METHOD = "setup";
-
-		try {
-			jobOp = new JobOperatorBridge();
-		} catch (Exception e) {
-			handleException(METHOD, e);
-		}
-	}
-
-	@BeforeMethod
-	@BeforeClass
-	public static void setUp()throws Exception {
+	@BeforeEach
+	public void setUp()throws Exception {
 		jobOp = new JobOperatorBridge();
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void cleanup() throws Exception {
 	}
 
 	private void begin(String str) {
-		Reporter.log("Begin test method: " + str + "<p>");
+		logger.info("Begin test method: " + str + "<p>");
 	}
 
 	/*
@@ -79,19 +64,19 @@ public class StepExecutionTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testOneStepExecutionStatus() throws Exception {
 
 		String METHOD = "testOneStepExecutionStatus";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: job_batchlet_1step.xml<p>");
+			logger.info("Locate job XML file: job_batchlet_1step.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_batchlet_1step");
 
-			Reporter.log("Obtaining StepExecutions for execution id: " + jobExec.getExecutionId() + "<p>");
+			logger.info("Obtaining StepExecutions for execution id: " + jobExec.getExecutionId() + "<p>");
 			List<StepExecution> steps = jobOp.getStepExecutions(jobExec.getExecutionId());
 
 			assertObjEquals(1, steps.size());
@@ -99,11 +84,11 @@ public class StepExecutionTests {
 			for (StepExecution step : steps) {
 				// make sure all steps finish successfully
 				showStepState(step);
-				Reporter.log("Step status = " + step.getBatchStatus() + "<p>");
+				logger.info("Step status = " + step.getBatchStatus() + "<p>");
 				assertObjEquals(BatchStatus.COMPLETED, step.getBatchStatus());
 			}
 
-			Reporter.log("Job execution status = " + jobExec.getBatchStatus() + "<p>");
+			logger.info("Job execution status = " + jobExec.getBatchStatus() + "<p>");
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -117,19 +102,19 @@ public class StepExecutionTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testFourStepExecutionStatus() throws Exception {
 
 		String METHOD = "testFourStepExecutionStatus";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: job_batchlet_4steps.xml<p>");
+			logger.info("Locate job XML file: job_batchlet_4steps.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_batchlet_4steps");
 
-			Reporter.log("Obtaining StepExecutions for execution id: " + jobExec.getExecutionId() + "<p>");
+			logger.info("Obtaining StepExecutions for execution id: " + jobExec.getExecutionId() + "<p>");
 			List<StepExecution> steps = jobOp.getStepExecutions(jobExec.getExecutionId());
 			assertObjEquals(4, steps.size());
 
@@ -137,14 +122,14 @@ public class StepExecutionTests {
 			for (StepExecution step : steps) {
 				// check that each step completed successfully
 				showStepState(step);
-				Reporter.log("Step status = " + step.getBatchStatus() + "<p>");
+				logger.info("Step status = " + step.getBatchStatus() + "<p>");
 				assertObjEquals(BatchStatus.COMPLETED, step.getBatchStatus());
 				
 				// Let's also make sure all four have unique IDs, to make sure the JobExecution id isn't being used say
 				assertWithMessage("New StepExecution id", !stepExecutionsSeen.contains(step.getStepExecutionId()));
 				stepExecutionsSeen.add(step.getStepExecutionId());
 			}
-			Reporter.log("Job execution status = " + jobExec.getBatchStatus() + "<p>");
+			logger.info("Job execution status = " + jobExec.getBatchStatus() + "<p>");
 			assertObjEquals(BatchStatus.COMPLETED, jobExec.getBatchStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -157,18 +142,18 @@ public class StepExecutionTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test  
+  
 	public void testFailedStepExecutionStatus() throws Exception {
 		String METHOD = "testFailedStepExecutionStatus";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: job_batchlet_failElement.xml<p>");
+			logger.info("Locate job XML file: job_batchlet_failElement.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_batchlet_failElement");
 
-			Reporter.log("Obtaining StepExecutions for execution id: " + jobExec.getExecutionId() + "<p>");
+			logger.info("Obtaining StepExecutions for execution id: " + jobExec.getExecutionId() + "<p>");
 			List<StepExecution> steps = jobOp.getStepExecutions(jobExec.getExecutionId());
 			assertObjEquals(1, steps.size());
 			for (StepExecution step : steps) {
@@ -177,8 +162,8 @@ public class StepExecutionTests {
 				showStepState(step);
 			}
 
-			Reporter.log("Job execution getExitStatus()="+jobExec.getExitStatus()+"<p>");
-			Reporter.log("Job execution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("Job execution getExitStatus()="+jobExec.getExitStatus()+"<p>");
+			logger.info("Job execution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals("TEST_FAIL", jobExec.getExitStatus());
 			assertObjEquals(BatchStatus.FAILED, jobExec.getBatchStatus());
 		} catch (Exception e) {
@@ -192,18 +177,18 @@ public class StepExecutionTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test  
+  
 	public void testStoppedStepExecutionStatus() throws Exception {
 		String METHOD = "testStoppedStepExecutionStatus";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: job_batchlet_stopElement.xml<p>");
+			logger.info("Locate job XML file: job_batchlet_stopElement.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_batchlet_stopElement");
 
-			Reporter.log("Obtaining StepExecutions for execution id: " + jobExec.getExecutionId() + "<p>");
+			logger.info("Obtaining StepExecutions for execution id: " + jobExec.getExecutionId() + "<p>");
 			List<StepExecution> steps = jobOp.getStepExecutions(jobExec.getExecutionId());
 			assertObjEquals(1, steps.size());
 			for (StepExecution step : steps) {
@@ -212,7 +197,7 @@ public class StepExecutionTests {
 				showStepState(step);
 			}
 
-			Reporter.log("Job execution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("Job execution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.STOPPED, jobExec.getBatchStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -225,37 +210,37 @@ public class StepExecutionTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test 
+ 
 	public void testPersistedStepData() throws Exception {
 		String METHOD = "testPersistedStepData";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: job_batchlet_persistedData.xml<p>");
+			logger.info("Locate job XML file: job_batchlet_persistedData.xml<p>");
 
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParameters = new Properties();
-			Reporter.log("force.failure=true<p>");
+			logger.info("force.failure=true<p>");
 			jobParameters.setProperty("force.failure" , "true");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_batchlet_persistedData", jobParameters);
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.FAILED, jobExec.getBatchStatus());
 
 			//This job should only have one step.
-			Reporter.log("Obtaining StepExecutions for execution id: " + jobExec.getExecutionId() + "<p>");
+			logger.info("Obtaining StepExecutions for execution id: " + jobExec.getExecutionId() + "<p>");
 			List<StepExecution> steps = jobOp.getStepExecutions(jobExec.getExecutionId());
 			StepExecution stepExec = steps.get(0);
 			assertObjEquals(1, steps.size());
 
-			Reporter.log("execution #1 StepExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("execution #1 StepExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.FAILED, stepExec.getBatchStatus());
 			assertObjEquals(4, ((MyPersistentUserData)stepExec.getPersistentUserData()).getData());
 
 			//jobParameters.setProperty("force.failure" , "false");
-			Reporter.log("Invoke restartJobAndWaitForResult with execution id: " + jobExec.getExecutionId() + "<p>");
+			logger.info("Invoke restartJobAndWaitForResult with execution id: " + jobExec.getExecutionId() + "<p>");
 			JobExecution restartedJobExec = jobOp.restartJobAndWaitForResult(jobExec.getExecutionId(),jobParameters);
 
 			//This job should only have one step.
@@ -263,7 +248,7 @@ public class StepExecutionTests {
 			steps = jobOp.getStepExecutions(restartedJobExec.getExecutionId());
 			stepExec = steps.get(0);
 
-			Reporter.log("execution #1 StepExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
+			logger.info("execution #1 StepExecution getBatchStatus()="+jobExec.getBatchStatus()+"<p>");
 			assertObjEquals(BatchStatus.COMPLETED, stepExec.getBatchStatus());
 			assertObjEquals(5, ((MyPersistentUserData)stepExec.getPersistentUserData()).getData());		
 
@@ -280,18 +265,18 @@ public class StepExecutionTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test  
+  
 	public void testStepExecutionExitStatus() throws Exception {
 		String METHOD = "testStepExecutionExitStatus";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: job_batchlet_failElement.xml<p>");
+			logger.info("Locate job XML file: job_batchlet_failElement.xml<p>");
 
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("job_batchlet_failElement");
 
-			Reporter.log("Obtaining StepExecutions for execution id: " + jobExec.getExecutionId() + "<p>");
+			logger.info("Obtaining StepExecutions for execution id: " + jobExec.getExecutionId() + "<p>");
 			List<StepExecution> steps = jobOp.getStepExecutions(jobExec.getExecutionId());
 			assertObjEquals(1, steps.size());
 			
@@ -299,8 +284,8 @@ public class StepExecutionTests {
 			showStepState(step);
 			assertWithMessage("Check step exit status", MyBatchletImpl.GOOD_EXIT_STATUS, step.getExitStatus());
 			assertWithMessage("Check step batch status", BatchStatus.COMPLETED, step.getBatchStatus());
-			Reporter.log("Job batch status =" + jobExec.getBatchStatus() + "<p>");
-			Reporter.log("Job exit status =" + jobExec.getExitStatus() + "<p>");
+			logger.info("Job batch status =" + jobExec.getBatchStatus() + "<p>");
+			logger.info("Job exit status =" + jobExec.getExitStatus() + "<p>");
 			assertWithMessage("Check job batch status", BatchStatus.FAILED, jobExec.getBatchStatus());
 			assertWithMessage("Check job exit status", "TEST_FAIL", jobExec.getExitStatus());
 		} catch (Exception e) {
@@ -314,17 +299,17 @@ public class StepExecutionTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test  
+  
 	public void testStepInFlowStepExecution() throws Exception {
 		String METHOD = "testStepInFlowStepExecution";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: job_batchlet_failElement.xml<p>");
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Locate job XML file: job_batchlet_failElement.xml<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("flow_transition_to_step");
 
-			Reporter.log("Obtaining StepExecutions for execution id: " + jobExec.getExecutionId() + "<p>");
+			logger.info("Obtaining StepExecutions for execution id: " + jobExec.getExecutionId() + "<p>");
 			List<StepExecution> steps = jobOp.getStepExecutions(jobExec.getExecutionId());
 			assertObjEquals(4, steps.size());
 			for (StepExecution step : steps) {
@@ -335,8 +320,8 @@ public class StepExecutionTests {
 			}
 
 			// Now check job level status
-			Reporter.log("Job batch status =" + jobExec.getBatchStatus() + "<p>");
-			Reporter.log("Job exit status =" + jobExec.getExitStatus() + "<p>");
+			logger.info("Job batch status =" + jobExec.getBatchStatus() + "<p>");
+			logger.info("Job exit status =" + jobExec.getExitStatus() + "<p>");
 			assertWithMessage("Check job batch status", BatchStatus.COMPLETED, jobExec.getBatchStatus());
 			assertWithMessage("Check job exit status", "flow1step1, flow1step2, flow1step3, step1", jobExec.getExitStatus());
 
@@ -351,21 +336,21 @@ public class StepExecutionTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test  
+  
 	public void testStepInFlowInSplitStepExecution() throws Exception {
 		String METHOD = "testStepInFlowInSplitStepExecution";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: split_batchlet_4steps.xml<p>");
-			Reporter.log("Invoke startJobAndWaitForResult for execution #1<p>");
+			logger.info("Locate job XML file: split_batchlet_4steps.xml<p>");
+			logger.info("Invoke startJobAndWaitForResult for execution #1<p>");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("split_batchlet_4steps");
 			
 			// Saves debugging time to check these two first in case they fail
 			assertWithMessage("Check job batch status", BatchStatus.COMPLETED, jobExec.getBatchStatus());
 			assertWithMessage("Check job exit status", "COMPLETED", jobExec.getExitStatus());
 
-			Reporter.log("Obtaining StepExecutions for execution id: " + jobExec.getExecutionId() + "<p>");
+			logger.info("Obtaining StepExecutions for execution id: " + jobExec.getExecutionId() + "<p>");
 			List<StepExecution> steps = jobOp.getStepExecutions(jobExec.getExecutionId());
 			assertObjEquals(4, steps.size());
 			for (StepExecution step : steps) {
@@ -374,8 +359,8 @@ public class StepExecutionTests {
 				assertWithMessage("Check step exit status", MyBatchletImpl.GOOD_EXIT_STATUS, step.getExitStatus());
 				assertWithMessage("Check step batch status", BatchStatus.COMPLETED, step.getBatchStatus());
 			}
-			Reporter.log("Job batch status =" + jobExec.getBatchStatus() + "<p>");
-			Reporter.log("Job exit status =" + jobExec.getExitStatus() + "<p>");
+			logger.info("Job batch status =" + jobExec.getBatchStatus() + "<p>");
+			logger.info("Job exit status =" + jobExec.getExitStatus() + "<p>");
 
 		} catch (Exception e) {
 			handleException(METHOD, e);
@@ -383,25 +368,25 @@ public class StepExecutionTests {
 	}
 
 	private void showStepState(StepExecution step) {
-		Reporter.log("---------------------------<p>");
-		Reporter.log("getStepName(): " + step.getStepName() + " - ");
-		Reporter.log("getStepExecutionId(): " + step.getStepExecutionId() + " - ");
+		logger.info("---------------------------<p>");
+		logger.info("getStepName(): " + step.getStepName() + " - ");
+		logger.info("getStepExecutionId(): " + step.getStepExecutionId() + " - ");
 		Metric[] metrics = step.getMetrics();
 
 		for (int i = 0; i < metrics.length; i++) {
-			Reporter.log(metrics[i].getType() + ": " + metrics[i].getValue() + " - ");
+			logger.info(metrics[i].getType() + ": " + metrics[i].getValue() + " - ");
 		}
 
-		Reporter.log("getStartTime(): " + step.getStartTime() + " - ");
-		Reporter.log("getEndTime(): " + step.getEndTime() + " - ");
-		Reporter.log("getBatchStatus(): " + step.getBatchStatus() + " - ");
-		Reporter.log("getExitStatus(): " + step.getExitStatus()+"<p>");
-		Reporter.log("---------------------------<p>");
+		logger.info("getStartTime(): " + step.getStartTime() + " - ");
+		logger.info("getEndTime(): " + step.getEndTime() + " - ");
+		logger.info("getBatchStatus(): " + step.getBatchStatus() + " - ");
+		logger.info("getExitStatus(): " + step.getExitStatus()+"<p>");
+		logger.info("---------------------------<p>");
 	}
 
 	private static void handleException(String methodName, Exception e) throws Exception {
-		Reporter.log("Caught exception: " + e.getMessage()+"<p>");
-		Reporter.log(methodName + " failed<p>");
+		logger.info("Caught exception: " + e.getMessage()+"<p>");
+		logger.info(methodName + " failed<p>");
 		throw e;
 	}
 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/StepLevelPropertiesTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/StepLevelPropertiesTests.java
@@ -28,15 +28,13 @@ import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.JobExecution;
 
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
+import java.util.logging.Logger;
 
-import org.junit.Before;
-import org.testng.Reporter;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.*;
 
 public class StepLevelPropertiesTests {
 
+	private static final Logger logger = Logger.getLogger(StepLevelPropertiesTests.class.getName());
 	private JobOperatorBridge jobOp = null;
 
 	private int PROPERTIES_COUNT = 3;
@@ -52,7 +50,7 @@ public class StepLevelPropertiesTests {
 	 * @throws IOException
 	 * @throws InterruptedException
 	 */
-	@Test @org.junit.Test
+	@Test
 	public void testStepLevelPropertiesCount() throws Exception {
 
 		String METHOD = "testStepLevelPropertiesCount";
@@ -63,13 +61,13 @@ public class StepLevelPropertiesTests {
 		
 		try {
 
-			Reporter.log("starting job");
+			logger.info("starting job");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("step_level_properties_count");
 
-			Reporter.log("Job Status = " + jobExec.getBatchStatus());
+			logger.info("Job Status = " + jobExec.getBatchStatus());
 			assertWithMessage("Job completed", BatchStatus.COMPLETED, jobExec.getBatchStatus());
 			assertWithMessage("Job completed", "VERY GOOD INVOCATION", jobExec.getExitStatus());
-			Reporter.log("job completed");
+			logger.info("job completed");
 		} catch (Exception e) {
 			handleException(METHOD, e);
 		}
@@ -84,23 +82,23 @@ public class StepLevelPropertiesTests {
 	 * @throws IOException
 	 * @throws InterruptedException
 	 */
-	@Test @org.junit.Test
+	@Test
 	public void testStepLevelPropertiesPropertyValue() throws Exception {
 
 		String METHOD = "testStepLevelPropertiesPropertyValue";
 
 		try {
 
-			Reporter.log("starting job");
+			logger.info("starting job");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("step_level_properties_value");
 
-			Reporter.log("Job Status = " + jobExec.getBatchStatus());
+			logger.info("Job Status = " + jobExec.getBatchStatus());
 			assertWithMessage("Job completed",BatchStatus.COMPLETED, jobExec.getBatchStatus());
-			Reporter.log("job completed");
+			logger.info("job completed");
 
 			assertWithMessage("Property value", FOO_VALUE, jobExec.getExitStatus());
 
-			Reporter.log("Job batchlet return code is the step property foo value " + FOO_VALUE);
+			logger.info("Job batchlet return code is the step property foo value " + FOO_VALUE);
 		} catch (Exception e) {
 			handleException(METHOD, e);
 		}
@@ -113,29 +111,29 @@ public class StepLevelPropertiesTests {
 	 * 
 	 * @throws InterruptedException
 	 */
-	@Test @org.junit.Test
+	@Test
 	public void testStepLevelPropertiesShouldNotBeAvailableThroughJobContext() throws Exception {
 
 		String METHOD = "testStepLevelPropertiesShouldNotBeAvailableThroughJobContext";
 
 		try {
 
-			Reporter.log("starting job");
+			logger.info("starting job");
 			JobExecution jobExec = jobOp.startJobAndWaitForResult("step_level_properties_scope");
 
-			Reporter.log("Job Status = " + jobExec.getBatchStatus());
+			logger.info("Job Status = " + jobExec.getBatchStatus());
 			assertWithMessage("Job completed", BatchStatus.COMPLETED, jobExec.getBatchStatus());
-			Reporter.log("job completed");
+			logger.info("job completed");
 			assertWithMessage("Step Level Property is not available through job context",BatchStatus.COMPLETED.name(), jobExec.getExitStatus());
-			Reporter.log("Job batchlet return code is the step.property read through job context (expected value=COMPLETED) " + jobExec.getExitStatus());
+			logger.info("Job batchlet return code is the step.property read through job context (expected value=COMPLETED) " + jobExec.getExitStatus());
 		} catch (Exception e) {
 			handleException(METHOD, e);
 		}
 	}
 
 	private static void handleException(String methodName, Exception e) throws Exception {
-		Reporter.log("Caught exception: " + e.getMessage()+"<p>");
-		Reporter.log(methodName + " failed<p>");
+		logger.info("Caught exception: " + e.getMessage()+"<p>");
+		logger.info(methodName + " failed<p>");
 		throw e;
 	}
 
@@ -156,14 +154,13 @@ public class StepLevelPropertiesTests {
 
 	}
 
-	@BeforeTest
-	@Before
+	@BeforeEach
 	public void beforeTest() throws ClassNotFoundException {
 		jobOp = new JobOperatorBridge();
 
 	}
 
-	@AfterTest
+	@AfterEach
 	public void afterTest() {
 		jobOp = null;
 	}

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/StopOrFailOnExitStatusWithRestartTests.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/tests/jslxml/StopOrFailOnExitStatusWithRestartTests.java
@@ -26,34 +26,22 @@ import java.util.Properties;
 import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.JobExecution;
 
-import org.junit.BeforeClass;
-import org.testng.Reporter;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
 import com.ibm.jbatch.tck.utils.JobOperatorBridge;
 import com.ibm.jbatch.tck.utils.TCKJobExecutionWrapper;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.*;
 
 public class StopOrFailOnExitStatusWithRestartTests {
 
-	private static JobOperatorBridge jobOp;
+	private static final Logger logger = Logger.getLogger(StopOrFailOnExitStatusWithRestartTests.class.getName());
+	private JobOperatorBridge jobOp;
 
 	private void begin(String str) {
-		Reporter.log("Begin test method: " + str+"<p>");
+		logger.info("Begin test method: " + str+"<p>");
 	}
 
-	public static void setup(String[] args, Properties props) throws Exception {
-		String METHOD = "setup";
-		try {
-			jobOp = new JobOperatorBridge();
-		} catch (Exception e) {
-			handleException(METHOD, e);
-		}
-	}
-
-	@BeforeMethod
-	@BeforeClass
-	public static void setUp() throws Exception {
+        @BeforeEach
+	public void setUp() throws Exception {
 		jobOp = new JobOperatorBridge();
 	}
 
@@ -66,7 +54,7 @@ public class StopOrFailOnExitStatusWithRestartTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testInvokeJobWithUserStopAndRestart() throws Exception {
 
 		String METHOD = "testInvokeJobWithUserStopAndRestart";
@@ -75,55 +63,55 @@ public class StopOrFailOnExitStatusWithRestartTests {
 		final String DEFAULT_SLEEP_TIME = "5000";
 
 		try {
-			Reporter.log("Locate job XML file: job_batchlet_longrunning.xml<p>");
+			logger.info("Locate job XML file: job_batchlet_longrunning.xml<p>");
 
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties overrideJobParams = new Properties();
-			Reporter.log("run.indefinitely=true<p>");
+			logger.info("run.indefinitely=true<p>");
 			overrideJobParams.setProperty("run.indefinitely" , "true");
 
-			Reporter.log("Invoke startJobWithoutWaitingForResult for execution #1<p>");
+			logger.info("Invoke startJobWithoutWaitingForResult for execution #1<p>");
 			TCKJobExecutionWrapper execution1 = jobOp.startJobWithoutWaitingForResult("job_batchlet_longrunning", overrideJobParams);
 
 			long execID = execution1.getExecutionId(); 
-			Reporter.log("StopRestart: Started job with execId=" + execID + "<p>");
+			logger.info("StopRestart: Started job with execId=" + execID + "<p>");
 
 			int sleepTime = Integer.parseInt(System.getProperty("StopOrFailOnExitStatusWithRestartTests.testInvokeJobWithUserStop.sleep",DEFAULT_SLEEP_TIME));
-			Reporter.log("Sleep " +  sleepTime  + "<p>");
+			logger.info("Sleep " +  sleepTime  + "<p>");
 			Thread.sleep(sleepTime); 
 
 			BatchStatus exec1BatchStatus = execution1.getBatchStatus();
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+ exec1BatchStatus + "<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+ exec1BatchStatus + "<p>");
 			
 			// Bug 5614 - Tolerate STARTING state in addition to STARTED 
 			boolean startedOrStarting = exec1BatchStatus == BatchStatus.STARTED || exec1BatchStatus == BatchStatus.STARTING;
 			assertWithMessage("Found BatchStatus of " + exec1BatchStatus.toString() + "; Hopefully job isn't finished already, if it is fail the test and use a longer sleep time within the batch step-related artifact.", startedOrStarting);
 
-			Reporter.log("Invoke stopJobAndWaitForResult");
+			logger.info("Invoke stopJobAndWaitForResult");
 			jobOp.stopJobAndWaitForResult(execution1);
 
 			JobExecution postStopJobExecution = jobOp.getJobExecution(execution1.getExecutionId());
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+postStopJobExecution.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+postStopJobExecution.getBatchStatus()+"<p>");
 			assertWithMessage("The stop should have taken effect by now, even though the batchlet artifact had control at the time of the stop, it should have returned control by now.", 
 					BatchStatus.STOPPED, postStopJobExecution.getBatchStatus());  
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+postStopJobExecution.getExitStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+postStopJobExecution.getExitStatus()+"<p>");
 			assertWithMessage("If this assert fails with an exit status of STOPPED, try increasing the sleep time. It's possible" +
 					"the JobOperator stop is being issued before the Batchlet has a chance to run.", "BATCHLET CANCELED BEFORE COMPLETION", postStopJobExecution.getExitStatus());
 
-			Reporter.log("Create job parameters for execution #2:<p>");
-			Reporter.log("run.indefinitely=false<p>");
+			logger.info("Create job parameters for execution #2:<p>");
+			logger.info("run.indefinitely=false<p>");
 			overrideJobParams.setProperty("run.indefinitely" , "false");
 
 
-			Reporter.log("Invoke restartJobAndWaitForResult with executionId: " + execution1.getInstanceId() + "<p>");
+			logger.info("Invoke restartJobAndWaitForResult with executionId: " + execution1.getInstanceId() + "<p>");
 			JobExecution execution2 = jobOp.restartJobAndWaitForResult(execution1.getExecutionId(),overrideJobParams);
 
-			Reporter.log("execution #2 JobExecution getBatchStatus()="+execution2.getBatchStatus()+"<p>");
+			logger.info("execution #2 JobExecution getBatchStatus()="+execution2.getBatchStatus()+"<p>");
 			assertWithMessage("If the restarted job hasn't completed yet then try increasing the sleep time.", 
 					BatchStatus.COMPLETED, execution2.getBatchStatus());
 
-			Reporter.log("execution #2 JobExecution getExitStatus()="+execution2.getExitStatus()+"<p>");
+			logger.info("execution #2 JobExecution getExitStatus()="+execution2.getExitStatus()+"<p>");
 			assertWithMessage("If this fails, the reason could be that step 1 didn't run the second time," + 
 					"though it should since it won't have completed successfully the first time.", 
 					"GOOD.STEP.GOOD.STEP", execution2.getExitStatus());
@@ -138,44 +126,44 @@ public class StopOrFailOnExitStatusWithRestartTests {
 	 * @test_Strategy: FIXME
 	 */
 	@Test
-	@org.junit.Test
+
 	public void testInvokeJobWithUncaughtExceptionFailAndRestart() throws Exception {
 		String METHOD = "testInvokeJobWithUncaughtExceptionFailAndRestart";
 		begin(METHOD);
 
 		try {
-			Reporter.log("Locate job XML file: job_batchlet_longrunning.xml<p>");
+			logger.info("Locate job XML file: job_batchlet_longrunning.xml<p>");
 
-			Reporter.log("Create job parameters for execution #1:<p>");
+			logger.info("Create job parameters for execution #1:<p>");
 			Properties jobParameters = new Properties();
-			Reporter.log("throw.exc.on.number.3=true<p>");
+			logger.info("throw.exc.on.number.3=true<p>");
 			jobParameters.setProperty("throw.exc.on.number.3" , "true");  // JSL default is 'false'
 
-			Reporter.log("Invoke startJobAndWaitForResult");
+			logger.info("Invoke startJobAndWaitForResult");
 			TCKJobExecutionWrapper firstJobExecution = jobOp.startJobAndWaitForResult("job_batchlet_longrunning", jobParameters);
 
-			Reporter.log("Started job with execId=" + firstJobExecution.getExecutionId()+"<p>");       
+			logger.info("Started job with execId=" + firstJobExecution.getExecutionId()+"<p>");       
 
-			Reporter.log("execution #1 JobExecution getBatchStatus()="+firstJobExecution.getBatchStatus()+"<p>");
-			Reporter.log("execution #1 JobExecution getExitStatus()="+firstJobExecution.getExitStatus()+"<p>");
+			logger.info("execution #1 JobExecution getBatchStatus()="+firstJobExecution.getBatchStatus()+"<p>");
+			logger.info("execution #1 JobExecution getExitStatus()="+firstJobExecution.getExitStatus()+"<p>");
 			assertWithMessage("If the job hasn't failed yet then try increasing the sleep time.", BatchStatus.FAILED, firstJobExecution.getBatchStatus());    
 			assertObjEquals("FAILED", firstJobExecution.getExitStatus());
 
-			Reporter.log("Create job parameters for execution #2:<p>");
+			logger.info("Create job parameters for execution #2:<p>");
 			Properties overrideJobParams = new Properties();
-			Reporter.log("throw.exc.on.number.3=false<p>");
-			Reporter.log("run.indefinitely=false<p>");
+			logger.info("throw.exc.on.number.3=false<p>");
+			logger.info("run.indefinitely=false<p>");
 			overrideJobParams.setProperty("throw.exc.on.number.3" , "false");
 			overrideJobParams.setProperty("run.indefinitely" , "false");
 
-			Reporter.log("Invoke restartJobAndWaitForResult with executionId: " + firstJobExecution.getInstanceId() + "<p>");
+			logger.info("Invoke restartJobAndWaitForResult with executionId: " + firstJobExecution.getInstanceId() + "<p>");
 			JobExecution secondJobExecution = jobOp.restartJobAndWaitForResult(firstJobExecution.getExecutionId(),overrideJobParams);
 
-			Reporter.log("execution #2 JobExecution getBatchStatus()="+secondJobExecution.getBatchStatus()+"<p>");
+			logger.info("execution #2 JobExecution getBatchStatus()="+secondJobExecution.getBatchStatus()+"<p>");
 			assertWithMessage("If the restarted job hasn't completed yet then try increasing the sleep time.", 
 					BatchStatus.COMPLETED, secondJobExecution.getBatchStatus());
 
-			Reporter.log("execution #2 JobExecution getExitStatus()="+secondJobExecution.getExitStatus()+"<p>");
+			logger.info("execution #2 JobExecution getExitStatus()="+secondJobExecution.getExitStatus()+"<p>");
 			assertWithMessage("If this fails with only \"GOOD.STEP\", the reason could be that step 1 didn't run the second time," + 
 					"though it should since it won't have completed successfully the first time.", 
 					"GOOD.STEP.GOOD.STEP", secondJobExecution.getExitStatus());
@@ -187,8 +175,8 @@ public class StopOrFailOnExitStatusWithRestartTests {
 
 
 	private static void handleException(String methodName, Exception e) throws Exception {
-		Reporter.log("Caught exception: " + e.getMessage()+"<p>");
-		Reporter.log(methodName + " failed<p>");
+		logger.info("Caught exception: " + e.getMessage()+"<p>");
+		logger.info(methodName + " failed<p>");
 		throw e;
 	}
 }

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/utils/JobOperatorBridge.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/utils/JobOperatorBridge.java
@@ -39,7 +39,7 @@ import javax.batch.runtime.JobExecution;
 import javax.batch.runtime.JobInstance;
 import javax.batch.runtime.StepExecution;
 
-import org.testng.Reporter;
+
 
 import com.ibm.jbatch.tck.spi.JobExecutionWaiter;
 import com.ibm.jbatch.tck.spi.JobExecutionWaiterFactory;
@@ -88,7 +88,7 @@ public class JobOperatorBridge {
 			terminatedJobExecution = waiter.awaitTermination();
 		} catch (JobExecutionTimeoutException e) {
 			logger.severe(TIMEOUT_MSG);
-			Reporter.log(TIMEOUT_MSG);
+			logger.info(TIMEOUT_MSG);
 			throw e;
 		}									
 
@@ -134,7 +134,7 @@ public class JobOperatorBridge {
 			terminatedJobExecution = waiter.awaitTermination();
 		} catch (JobExecutionTimeoutException e) {
 			logger.severe(TIMEOUT_MSG);
-			Reporter.log(TIMEOUT_MSG);
+			logger.info(TIMEOUT_MSG);
 			throw e;
 		}									
 
@@ -152,7 +152,7 @@ public class JobOperatorBridge {
 			terminatedJobExecution = waiter.awaitTermination();
 		} catch (JobExecutionTimeoutException e) {
 			logger.severe(TIMEOUT_MSG);
-			Reporter.log(TIMEOUT_MSG);
+			logger.info(TIMEOUT_MSG);
 			throw e;
 		}									
 

--- a/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/utils/ServiceGateway.java
+++ b/com.ibm.jbatch.tck/src/main/java/com/ibm/jbatch/tck/utils/ServiceGateway.java
@@ -22,7 +22,7 @@ import java.util.ServiceLoader;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.testng.Reporter;
+
 
 import com.ibm.jbatch.tck.spi.JobExecutionWaiterFactory;
 
@@ -39,7 +39,7 @@ public class ServiceGateway {
                 if (logger.isLoggable(Level.FINE)) {
                     logger.fine("Loaded JobExecutionWaiterFactory with className = " + provider.getClass().getCanonicalName());
                 }
-                Reporter.log("Loaded JobExecutionWaiterFactory with className = " + provider.getClass().getCanonicalName() + "<p>");
+                logger.info("Loaded JobExecutionWaiterFactory with className = " + provider.getClass().getCanonicalName() + "<p>");
                 // Use first one
                 services = provider;
                 break;

--- a/com.ibm.jbatch.tck/src/main/resources/testprofiles/batch-tck-impl-EE-suite-excludes.txt
+++ b/com.ibm.jbatch.tck/src/main/resources/testprofiles/batch-tck-impl-EE-suite-excludes.txt
@@ -1,0 +1,3 @@
+*/jslxml/ListenerOnErrorTests.java
+*/jslxml/ParallelContextPropagationTests.java
+*/jslxml/PartitionRerunTests.java

--- a/com.ibm.jbatch.tck/src/main/resources/testprofiles/batch-tck-impl-EE-suite-includes.txt
+++ b/com.ibm.jbatch.tck/src/main/resources/testprofiles/batch-tck-impl-EE-suite-includes.txt
@@ -1,0 +1,1 @@
+*/tests/**/*Tests.java

--- a/com.ibm.jbatch.tck/src/main/resources/testprofiles/batch-tck-impl-SE-suite-excludes.txt
+++ b/com.ibm.jbatch.tck/src/main/resources/testprofiles/batch-tck-impl-SE-suite-excludes.txt
@@ -1,0 +1,3 @@
+*/jslxml/ListenerOnErrorTests.java
+*/jslxml/ParallelContextPropagationTests.java
+*/jslxml/PartitionRerunTests.java

--- a/com.ibm.jbatch.tck/src/main/resources/testprofiles/batch-tck-impl-SE-suite-includes.txt
+++ b/com.ibm.jbatch.tck/src/main/resources/testprofiles/batch-tck-impl-SE-suite-includes.txt
@@ -1,0 +1,1 @@
+*/tests/jslxml/*Tests.java

--- a/jakarta.batch.official.tck/pom.xml
+++ b/jakarta.batch.official.tck/pom.xml
@@ -43,13 +43,9 @@
     <name>Jakarta Batch Official TCK Distribution ZIP</name>
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-        </dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>        
         <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>

--- a/jakarta.batch.official.tck/tck.dist.xml
+++ b/jakarta.batch.official.tck/tck.dist.xml
@@ -93,6 +93,22 @@
             <outputDirectory>/doc</outputDirectory>
         </file>
         <file>
+            <source>../com.ibm.jbatch.tck/src/main/resources/testprofiles/batch-tck-impl-SE-suite-includes.txt</source>
+            <outputDirectory>/artifacts</outputDirectory>
+        </file>
+        <file>
+            <source>../com.ibm.jbatch.tck/src/main/resources/testprofiles/batch-tck-impl-SE-suite-excludes.txt</source>
+            <outputDirectory>/artifacts</outputDirectory>
+        </file>
+        <file>
+            <source>../com.ibm.jbatch.tck/src/main/resources/testprofiles/batch-tck-impl-EE-suite-includes.txt</source>
+            <outputDirectory>/artifacts</outputDirectory>
+        </file>
+        <file>
+            <source>../com.ibm.jbatch.tck/src/main/resources/testprofiles/batch-tck-impl-EE-suite-excludes.txt</source>
+            <outputDirectory>/artifacts</outputDirectory>
+        </file>
+        <file>
             <source>../com.ibm.jbatch.tck/src/main/resources/testng/batch-tck-impl-SE-suite.xml</source>
             <outputDirectory>/artifacts</outputDirectory>
         </file>

--- a/pom.xml
+++ b/pom.xml
@@ -146,13 +146,13 @@
         <!-- Dependencies -->
         <version.jakarta.enterprise.jakarta.enterprise.cdi-api>2.0.1</version.jakarta.enterprise.jakarta.enterprise.cdi-api>
         <version.jakarta.inject.jakarta.inject-api>1.0</version.jakarta.inject.jakarta.inject-api>
-        <version.org.testng.testng>6.8.8</version.org.testng.testng>
+        <version.org.junit.jupiter>5.6.1</version.org.junit.jupiter>
         <version.com.beust.jcommander>1.60</version.com.beust.jcommander>
         <version.org.sonatype.plugins.nexus-staging-maven-plugin>1.6.6</version.org.sonatype.plugins.nexus-staging-maven-plugin>
         <version.com.mycila.maven-license-plugin.maven-license-plugin>1.10.b1</version.com.mycila.maven-license-plugin.maven-license-plugin>
         <version.org.apache.maven.plugins.maven-antrun-plugin>1.8</version.org.apache.maven.plugins.maven-antrun-plugin>
         <version.org.apache.maven.plugins.maven-compiler-plugin>2.0.2</version.org.apache.maven.plugins.maven-compiler-plugin>
-        <version.org.apache.maven.plugins.maven-failsafe-plugin>2.18</version.org.apache.maven.plugins.maven-failsafe-plugin>
+        <version.org.apache.maven.plugins.maven-failsafe-plugin>2.22.2</version.org.apache.maven.plugins.maven-failsafe-plugin>
         <version.org.apache.maven.plugins.maven-gpg-plugin>1.4</version.org.apache.maven.plugins.maven-gpg-plugin>
         <version.org.apache.maven.plugins.maven-jar-plugin>2.4</version.org.apache.maven.plugins.maven-jar-plugin>
         <version.org.apache.maven.plugins.maven-javadoc-plugin>2.9.1</version.org.apache.maven.plugins.maven-javadoc-plugin>
@@ -258,10 +258,10 @@
                 <version>1.1</version>
             </dependency>
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.10</version>
-            </dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>${version.org.junit.jupiter}</version>
+            </dependency>        
             <dependency>
                 <groupId>net.java.sigtest</groupId>
                 <artifactId>sigtestdev</artifactId>
@@ -281,11 +281,6 @@
                 <groupId>org.jboss.weld.se</groupId>
                 <artifactId>weld-se</artifactId>
                 <version>${version.org.jboss.weld.se.weld-se}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.testng</groupId>
-                <artifactId>testng</artifactId>
-                <version>${version.org.testng.testng}</version>
             </dependency>
             <dependency>
                 <groupId>com.beust</groupId>


### PR DESCRIPTION
Converts all TCK tests from TestNG to Junit 5. It also modifies the example TCK runner for JBatch to use work with the converted tests.

This PR also removes several public static void setup( methods in some tests which seemed to be not used at all.

Here's an example how to run the converted TCK on Payara Server using an unofficial JUnit 5 Arquillian extension: https://github.com/OndroMih/Payara-Batch-TCK-Runner/tree/poc-junit5-over-arquillian

More details on my blog: https://ondro.inginea.eu/index.php/possible-ways-to-use-arquillian-in-jakarta-ee-tcks/